### PR TITLE
Stop only the pebble services defined in the container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -548,7 +548,7 @@ class Worker(ops.Object):
         """
         services = tuple(self._container.get_plan().services)
         if not services:
-            logger.warning("nothing to stop: no services found in layer or plan")
+            logger.warning("nothing to stop: no services found in plan")
             return
         self._container.stop(*services)
 

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -546,19 +546,20 @@ class Worker(ops.Object):
 
         Assumes that pebble can connect.
         """
+        curr_services = self._container.get_plan().services
         # we might be unable to retrieve self.pebble_layer if something goes wrong generating it
         # for example because we're being torn down and the environment is being weird
         services = tuple(
             self.pebble_layer.services
             if self.pebble_layer
-            else self._container.get_plan().services
+            else curr_services
         )
 
         if not services:
             logger.warning("nothing to stop: no services found in layer or plan")
             return
-
-        self._container.stop(*services)
+        if curr_services:
+            self._container.stop(*services)
 
     def _update_cluster_relation(self) -> None:
         """Publish all the worker information to relation data."""

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -546,20 +546,11 @@ class Worker(ops.Object):
 
         Assumes that pebble can connect.
         """
-        curr_services = self._container.get_plan().services
-        # we might be unable to retrieve self.pebble_layer if something goes wrong generating it
-        # for example because we're being torn down and the environment is being weird
-        services = tuple(
-            self.pebble_layer.services
-            if self.pebble_layer
-            else curr_services
-        )
-
+        services = tuple(self._container.get_plan().services)
         if not services:
             logger.warning("nothing to stop: no services found in layer or plan")
             return
-        if curr_services:
-            self._container.stop(*services)
+        self._container.stop(*services)
 
     def _update_cluster_relation(self) -> None:
         """Publish all the worker information to relation data."""

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -546,11 +546,11 @@ class Worker(ops.Object):
 
         Assumes that pebble can connect.
         """
-        services = tuple(self._container.get_plan().services)
-        if not services:
+        container_services = tuple(self._container.get_plan().services)
+        if not container_services:
             logger.warning("nothing to stop: no services found in plan")
             return
-        self._container.stop(*services)
+        self._container.stop(*container_services)
 
     def _update_cluster_relation(self) -> None:
         """Publish all the worker information to relation data."""


### PR DESCRIPTION
## Issue
In case of using a worker workload image that doesn't define a pebble service (e.g. the upstream docker image), the shared worker raises an error as it tries to stop the pebble services defined in the layer generated by the charm, which are not necessarily running in the container.

## Solution
Refactor the `stop()` method to only look at the services defined in the container, as we only care about stopping the services that are currently running.


