### PR TITLE
charm tracing for worker and coordinator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "0.0.4"
+version = "0.1.0"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]
@@ -14,7 +14,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = [
     "crossplane",
-    "ops",
+    "ops[tracing]",
     "pydantic",
     "lightkube>=v0.15.4",
     "cosl>=1",

--- a/src/coordinated_workers/__init__.py
+++ b/src/coordinated_workers/__init__.py
@@ -37,4 +37,3 @@ NginxConfig = _LazyModule(".nginx")
 Nginx = _LazyModule(".nginx")
 NginxPrometheusExporter = _LazyModule(".nginx")
 Worker = _LazyModule(".worker")
-

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -31,6 +31,9 @@ import ops
 import ops_tracing
 import pydantic
 import yaml
+from cosl.interfaces.datasource_exchange import DatasourceExchange
+from ops import StatusBase
+
 from coordinated_workers import worker
 from coordinated_workers.helpers import check_libs_installed
 from coordinated_workers.interfaces.cluster import ClusterProvider, RemoteWriteEndpoint
@@ -40,8 +43,6 @@ from coordinated_workers.nginx import (
     NginxMappingOverrides,
     NginxPrometheusExporter,
 )
-from cosl.interfaces.datasource_exchange import DatasourceExchange
-from ops import StatusBase
 
 check_libs_installed(
     "charms.data_platform_libs.v0.s3",

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -463,7 +463,7 @@ class Coordinator(ops.Object):
             logger.debug(f"expected K8s-style fqdn, but got {hostname} instead")
             return hostname
 
-        dns_name_parts = hostname_parts[hostname_parts.index("svc"):]
+        dns_name_parts = hostname_parts[hostname_parts.index("svc") :]
         dns_name = ".".join(dns_name_parts)  # 'svc.cluster.local'
         return f"{self._charm.app.name}.{self._charm.model.name}.{dns_name}"  # 'tempo.model.svc.cluster.local'
 
@@ -816,6 +816,5 @@ class Coordinator(ops.Object):
         """Configure ops.tracing to send traces to a tracing backend."""
         if self.charm_tracing.is_ready():
             ops_tracing.set_destination(
-                url=self.charm_tracing.get_endpoint("otlp_http"),
-                ca=self.cert_handler.ca_cert
+                url=self.charm_tracing.get_endpoint("otlp_http"), ca=self.cert_handler.ca_cert
             )

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -31,9 +31,6 @@ import ops
 import ops_tracing
 import pydantic
 import yaml
-from cosl.interfaces.datasource_exchange import DatasourceExchange
-from ops import StatusBase
-
 from coordinated_workers import worker
 from coordinated_workers.helpers import check_libs_installed
 from coordinated_workers.interfaces.cluster import ClusterProvider, RemoteWriteEndpoint
@@ -43,6 +40,8 @@ from coordinated_workers.nginx import (
     NginxMappingOverrides,
     NginxPrometheusExporter,
 )
+from cosl.interfaces.datasource_exchange import DatasourceExchange
+from ops import StatusBase
 
 check_libs_installed(
     "charms.data_platform_libs.v0.s3",
@@ -130,12 +129,12 @@ class ClusterRolesConfig:
         is_minimal_valid = set(self.minimal_deployment).issubset(self.roles)
         is_recommended_valid = set(self.recommended_deployment).issubset(self.roles)
         if not all(
-                [
-                    are_meta_keys_valid,
-                    are_meta_values_valid,
-                    is_minimal_valid,
-                    is_recommended_valid,
-                ]
+            [
+                are_meta_keys_valid,
+                are_meta_values_valid,
+                is_minimal_valid,
+                is_recommended_valid,
+            ]
         ):
             raise ClusterRolesConfigError(
                 "Invalid ClusterRolesConfig: The configuration is not coherent."
@@ -147,8 +146,8 @@ class ClusterRolesConfig:
 
 
 def _validate_container_name(
-        container_name: Optional[str],
-        resources_requests: Optional[Callable[["Coordinator"], Dict[str, str]]],
+    container_name: Optional[str],
+    resources_requests: Optional[Callable[["Coordinator"], Dict[str, str]]],
 ):
     """Raise `ValueError` if `resources_requests` is not None and `container_name` is None."""
     if resources_requests is not None and container_name is None:
@@ -195,24 +194,24 @@ class Coordinator(ops.Object):
     """
 
     def __init__(
-            self,
-            charm: ops.CharmBase,
-            roles_config: ClusterRolesConfig,
-            external_url: str,  # the ingressed url if we have ingress, else fqdn
-            worker_metrics_port: int,
-            endpoints: _EndpointMapping,
-            nginx_config: NginxConfig,
-            workers_config: Callable[["Coordinator"], str],
-            worker_ports: Optional[Callable[[str], Sequence[int]]] = None,
-            nginx_options: Optional[NginxMappingOverrides] = None,
-            is_coherent: Optional[Callable[[ClusterProvider, ClusterRolesConfig], bool]] = None,
-            is_recommended: Optional[Callable[[ClusterProvider, ClusterRolesConfig], bool]] = None,
-            resources_limit_options: Optional[_ResourceLimitOptionsMapping] = None,
-            resources_requests: Optional[Callable[["Coordinator"], Dict[str, str]]] = None,
-            container_name: Optional[str] = None,
-            remote_write_endpoints: Optional[Callable[[], List[RemoteWriteEndpoint]]] = None,
-            workload_tracing_protocols: Optional[List[ReceiverProtocol]] = None,
-            catalogue_item: Optional[CatalogueItem] = None,
+        self,
+        charm: ops.CharmBase,
+        roles_config: ClusterRolesConfig,
+        external_url: str,  # the ingressed url if we have ingress, else fqdn
+        worker_metrics_port: int,
+        endpoints: _EndpointMapping,
+        nginx_config: NginxConfig,
+        workers_config: Callable[["Coordinator"], str],
+        worker_ports: Optional[Callable[[str], Sequence[int]]] = None,
+        nginx_options: Optional[NginxMappingOverrides] = None,
+        is_coherent: Optional[Callable[[ClusterProvider, ClusterRolesConfig], bool]] = None,
+        is_recommended: Optional[Callable[[ClusterProvider, ClusterRolesConfig], bool]] = None,
+        resources_limit_options: Optional[_ResourceLimitOptionsMapping] = None,
+        resources_requests: Optional[Callable[["Coordinator"], Dict[str, str]]] = None,
+        container_name: Optional[str] = None,
+        remote_write_endpoints: Optional[Callable[[], List[RemoteWriteEndpoint]]] = None,
+        workload_tracing_protocols: Optional[List[ReceiverProtocol]] = None,
+        catalogue_item: Optional[CatalogueItem] = None,
     ):
         """Constructor for a Coordinator object.
 
@@ -477,10 +476,10 @@ class Coordinator(ops.Object):
     def tls_available(self) -> bool:
         """Return True if tls is enabled and the necessary certs are found."""
         return (
-                self.cert_handler.enabled
-                and (self.cert_handler.server_cert is not None)
-                and (self.cert_handler.private_key is not None)  # type: ignore
-                and (self.cert_handler.ca_cert is not None)
+            self.cert_handler.enabled
+            and (self.cert_handler.server_cert is not None)
+            and (self.cert_handler.private_key is not None)  # type: ignore
+            and (self.cert_handler.ca_cert is not None)
         )
 
     @property

--- a/src/coordinated_workers/interfaces/cluster.py
+++ b/src/coordinated_workers/interfaces/cluster.py
@@ -273,7 +273,6 @@ class ClusterProvider(Object):
         """Go through the worker's unit databags to collect all the addresses published by the units, by role."""
         data: Dict[str, Set[str]] = collections.defaultdict(set)
         for relation in self._relations:
-
             if not relation.app:
                 log.debug(f"skipped {relation} as .app is None")
                 continue
@@ -402,13 +401,16 @@ class ClusterRequirer(Object):
         )
 
         self.framework.observe(
-            self._charm.on[endpoint].relation_changed, self._on_cluster_relation_changed  # type: ignore
+            self._charm.on[endpoint].relation_changed,
+            self._on_cluster_relation_changed,  # type: ignore
         )
         self.framework.observe(
-            self._charm.on[endpoint].relation_created, self._on_cluster_relation_created  # type: ignore
+            self._charm.on[endpoint].relation_created,
+            self._on_cluster_relation_created,  # type: ignore
         )
         self.framework.observe(
-            self._charm.on[endpoint].relation_broken, self._on_cluster_relation_broken  # type: ignore
+            self._charm.on[endpoint].relation_broken,
+            self._on_cluster_relation_broken,  # type: ignore
         )
 
     def _on_cluster_relation_broken(self, _event: ops.RelationBrokenEvent):

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -525,7 +525,6 @@ class NginxConfig:
         backends: List[str],
         listen_tls: bool,
     ) -> List[Dict[str, Any]]:
-
         nginx_locations: List[Dict[str, Any]] = []
 
         if self._enable_health_check:

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -213,12 +213,12 @@ class Worker(ops.Object):
 
     def _on_pebble_check_failed(self, event: ops.PebbleCheckFailedEvent):
         if event.info.name == "ready":
-            logger.warning("Pebble `ready` check started to fail: " "worker node is down.")
+            logger.warning("Pebble `ready` check started to fail: worker node is down.")
             # collect-status will detect that we're not ready and set waiting status.
 
     def _on_pebble_check_recovered(self, event: ops.PebbleCheckFailedEvent):
         if event.info.name == "ready":
-            logger.info("Pebble `ready` check is now passing: " "worker node is up.")
+            logger.info("Pebble `ready` check is now passing: worker node is up.")
             # collect-status will detect that we're ready and set active status.
 
     @property
@@ -861,7 +861,9 @@ class Worker(ops.Object):
             "memory": self._charm.model.config.get(memory_limit_key),
         }
         return adjust_resource_requirements(
-            limits, self._resources_requests_getter(), adhere_to_requests=True  # type: ignore
+            limits,
+            self._resources_requests_getter(),
+            adhere_to_requests=True,  # type: ignore
         )
 
     def _setup_charm_tracing(self):

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -862,8 +862,8 @@ class Worker(ops.Object):
         }
         return adjust_resource_requirements(
             limits,
-            self._resources_requests_getter(),
-            adhere_to_requests=True,  # type: ignore
+            self._resources_requests_getter(),  # type: ignore
+            adhere_to_requests=True,
         )
 
     def _setup_charm_tracing(self):

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -196,7 +196,7 @@ def coordinator_charm(request):
 
 
 def test_worker_roles_subset_of_minimal_deployment(
-        coordinator_state: testing.State, coordinator_charm: ops.CharmBase
+    coordinator_state: testing.State, coordinator_charm: ops.CharmBase
 ):
     # Test that the combination of worker roles is a subset of the minimal deployment roles
 
@@ -222,8 +222,8 @@ def test_worker_roles_subset_of_minimal_deployment(
 
 
 def test_worker_ports_published(
-        coordinator_state: testing.State,
-        coordinator_charm: ops.CharmBase,
+    coordinator_state: testing.State,
+    coordinator_charm: ops.CharmBase,
 ):
     ports_per_role = {"read": (10, 22), "write": (1, 2132)}
 
@@ -252,7 +252,7 @@ def test_worker_ports_published(
 
 
 def test_without_s3_integration_raises_error(
-        coordinator_state: testing.State, coordinator_charm: ops.CharmBase
+    coordinator_state: testing.State, coordinator_charm: ops.CharmBase
 ):
     # Test that a charm without an s3 integration raises S3NotFoundError
 
@@ -286,15 +286,15 @@ def test_without_s3_integration_raises_error(
     ),
 )
 def test_s3_integration(
-        coordinator_state: testing.State,
-        coordinator_charm: ops.CharmBase,
-        region,
-        endpoint,
-        endpoint_stripped,
-        secret_key,
-        access_key,
-        bucket,
-        tls_ca_chain,
+    coordinator_state: testing.State,
+    coordinator_charm: ops.CharmBase,
+    region,
+    endpoint,
+    endpoint_stripped,
+    secret_key,
+    access_key,
+    bucket,
+    tls_ca_chain,
 ):
     # Test that a charm with a s3 integration gives the expected _s3_config
 
@@ -341,7 +341,7 @@ def test_s3_integration(
 
 
 def test_tracing_receivers_urls(
-        coordinator_state: testing.State, coordinator_charm: ops.CharmBase
+    coordinator_state: testing.State, coordinator_charm: ops.CharmBase
 ):
     charm_tracing_relation = testing.Relation(
         endpoint="my-charm-tracing",
@@ -385,8 +385,8 @@ def find_relation(relations, endpoint):
 
 @pytest.mark.parametrize("tls", (True, False))
 def test_charm_tracing_configured(
-        coordinator_state: testing.State, coordinator_charm: ops.CharmBase,
-        tls: bool
+    coordinator_state: testing.State, coordinator_charm: ops.CharmBase,
+    tls: bool
 ):
     # GIVEN a charm tracing integration (and tls?)
     relations = set(coordinator_state.relations)
@@ -490,7 +490,7 @@ def test_invalid_databag_content(coordinator_charm: ops.CharmBase, event):
 
 @pytest.mark.parametrize("app", (True, False))
 def test_invalid_app_or_unit_databag(
-        coordinator_charm: ops.CharmBase, coordinator_state, app: bool
+    coordinator_charm: ops.CharmBase, coordinator_state, app: bool
 ):
     # Test that when a relation changes and either the app or unit data is invalid
     #   the worker emits a ClusterRemovedEvent
@@ -558,9 +558,9 @@ def test_invalid_app_or_unit_databag(
     ),
 )
 def test_app_hostname(
-        coordinator_charm: ops.CharmBase,
-        hostname: str,
-        expected_app_hostname: str,
+    coordinator_charm: ops.CharmBase,
+    hostname: str,
+    expected_app_hostname: str,
 ):
     # GIVEN a hostname
     ctx = testing.Context(coordinator_charm, meta=coordinator_charm.META)

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -212,8 +212,8 @@ def test_worker_roles_subset_of_minimal_deployment(
 
     # WHEN we process any event
     with ctx(
-            ctx.on.update_status(),
-            state=dataclasses.replace(coordinator_state, relations=missing_backend_worker_relation),
+        ctx.on.update_status(),
+        state=dataclasses.replace(coordinator_state, relations=missing_backend_worker_relation),
     ) as mgr:
         charm: coordinator_charm = mgr.charm
 
@@ -264,8 +264,8 @@ def test_without_s3_integration_raises_error(
 
     # WHEN we process any event
     with ctx(
-            ctx.on.update_status(),
-            state=dataclasses.replace(coordinator_state, relations=relations_without_s3),
+        ctx.on.update_status(),
+        state=dataclasses.replace(coordinator_state, relations=relations_without_s3),
     ) as mgr:
         # THEN the _s3_config method raises an S3NotFoundError
         with pytest.raises(S3NotFoundError):
@@ -318,13 +318,13 @@ def test_s3_integration(
 
     # WHEN we process any event
     with ctx(
-            ctx.on.update_status(),
-            state=dataclasses.replace(
-                coordinator_state,
-                leader=True,
-                relations=relations_except_s3
-                          + [dataclasses.replace(s3_relation, remote_app_data=s3_app_data)],
-            ),
+        ctx.on.update_status(),
+        state=dataclasses.replace(
+            coordinator_state,
+            leader=True,
+            relations=relations_except_s3
+                      + [dataclasses.replace(s3_relation, remote_app_data=s3_app_data)],
+        ),
     ) as mgr:
         # THEN the s3_connection_info method returns the expected data structure
         coordinator: Coordinator = mgr.charm.coordinator
@@ -364,10 +364,10 @@ def test_tracing_receivers_urls(
     )
     ctx = testing.Context(coordinator_charm, meta=coordinator_charm.META)
     with ctx(
-            ctx.on.update_status(),
-            state=dataclasses.replace(
-                coordinator_state, relations=[charm_tracing_relation, workload_tracing_relation]
-            ),
+        ctx.on.update_status(),
+        state=dataclasses.replace(
+            coordinator_state, relations=[charm_tracing_relation, workload_tracing_relation]
+        ),
     ) as mgr:
         coordinator: Coordinator = mgr.charm.coordinator
         assert coordinator._charm_tracing_receivers_urls == {

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -23,7 +23,8 @@ from coordinated_workers.interfaces.cluster import (
 from coordinated_workers.nginx import NginxConfig
 from tests.unit.test_worker import MyCharm
 
-MOCK_CERTS_DATA="<TLS_STUFF>"
+MOCK_CERTS_DATA = "<TLS_STUFF>"
+
 
 @pytest.fixture
 def coordinator_state():
@@ -40,12 +41,14 @@ def coordinator_state():
         interface="certificates",
         remote_app_data={
             "certificates": json.dumps(
-                [{
-                    "certificate": MOCK_CERTS_DATA,
-                    "ca": MOCK_CERTS_DATA,
-                    "chain": MOCK_CERTS_DATA,
-                    "certificate_signing_request": MOCK_CERTS_DATA,
-                }]
+                [
+                    {
+                        "certificate": MOCK_CERTS_DATA,
+                        "ca": MOCK_CERTS_DATA,
+                        "chain": MOCK_CERTS_DATA,
+                        "certificate_signing_request": MOCK_CERTS_DATA,
+                    }
+                ]
             ),
         },
     )
@@ -280,9 +283,9 @@ def test_without_s3_integration_raises_error(
 @pytest.mark.parametrize(
     "endpoint, endpoint_stripped",
     (
-            ("example.com", "example.com"),
-            ("http://example.com", "example.com"),
-            ("https://example.com", "example.com"),
+        ("example.com", "example.com"),
+        ("http://example.com", "example.com"),
+        ("https://example.com", "example.com"),
     ),
 )
 def test_s3_integration(
@@ -323,7 +326,7 @@ def test_s3_integration(
             coordinator_state,
             leader=True,
             relations=relations_except_s3
-                      + [dataclasses.replace(s3_relation, remote_app_data=s3_app_data)],
+            + [dataclasses.replace(s3_relation, remote_app_data=s3_app_data)],
         ),
     ) as mgr:
         # THEN the s3_connection_info method returns the expected data structure
@@ -336,7 +339,7 @@ def test_s3_integration(
         assert coordinator.s3_connection_info.tls_ca_chain == tls_ca_chain
         assert coordinator._s3_config["endpoint"] == endpoint_stripped
         assert coordinator._s3_config["insecure"] is not (
-                tls_ca_chain or urlparse(endpoint).scheme == "https"
+            tls_ca_chain or urlparse(endpoint).scheme == "https"
         )
 
 
@@ -363,6 +366,7 @@ def test_tracing_receivers_urls(
         },
     )
     ctx = testing.Context(coordinator_charm, meta=coordinator_charm.META)
+
     with ctx(
         ctx.on.update_status(),
         state=dataclasses.replace(
@@ -385,8 +389,7 @@ def find_relation(relations, endpoint):
 
 @pytest.mark.parametrize("tls", (True, False))
 def test_charm_tracing_configured(
-    coordinator_state: testing.State, coordinator_charm: ops.CharmBase,
-    tls: bool
+    coordinator_state: testing.State, coordinator_charm: ops.CharmBase, tls: bool
 ):
     # GIVEN a charm tracing integration (and tls?)
     relations = set(coordinator_state.relations)
@@ -406,7 +409,9 @@ def test_charm_tracing_configured(
     certs_relation = find_relation(relations, "my-certificates")
     if tls:
         # it's truly too much work to figure out how to mock a certificate relation.
-        tls_mock = patch.object(CertHandler, "ca_cert", new_callable=PropertyMock, return_value=MOCK_CERTS_DATA)
+        tls_mock = patch.object(
+            CertHandler, "ca_cert", new_callable=PropertyMock, return_value=MOCK_CERTS_DATA
+        )
     else:
         tls_mock = nullcontext()
         relations.remove(certs_relation)
@@ -418,9 +423,7 @@ def test_charm_tracing_configured(
         with patch("ops_tracing.set_destination") as p:
             ctx.run(
                 ctx.on.update_status(),
-                state=dataclasses.replace(
-                    coordinator_state, relations=relations
-                )
+                state=dataclasses.replace(coordinator_state, relations=relations),
             )
     p.assert_called_with(url=url, ca=MOCK_CERTS_DATA if tls else None)
 
@@ -428,10 +431,10 @@ def test_charm_tracing_configured(
 @pytest.mark.parametrize(
     "event",
     (
-            testing.CharmEvents.update_status(),
-            testing.CharmEvents.start(),
-            testing.CharmEvents.install(),
-            testing.CharmEvents.config_changed(),
+        testing.CharmEvents.update_status(),
+        testing.CharmEvents.start(),
+        testing.CharmEvents.install(),
+        testing.CharmEvents.config_changed(),
     ),
 )
 def test_invalid_databag_content(coordinator_charm: ops.CharmBase, event):
@@ -540,21 +543,21 @@ def test_invalid_app_or_unit_databag(
 @pytest.mark.parametrize(
     ("hostname", "expected_app_hostname"),
     (
-            (
-                    "foo-app-0.foo-app-headless.test.svc.cluster.local",
-                    "foo-app.test.svc.cluster.local",
-            ),
-            (
-                    "foo-app-0.foo-app-headless.test.svc.custom.domain",
-                    "foo-app.test.svc.custom.domain",
-            ),
-            (
-                    "foo-app-0.foo-app-headless.test.svc.custom.svc.domain",
-                    "foo-app.test.svc.custom.svc.domain",
-            ),
-            ("localhost", "localhost"),
-            ("my.custom.domain", "my.custom.domain"),
-            ("192.0.2.1", "192.0.2.1"),
+        (
+            "foo-app-0.foo-app-headless.test.svc.cluster.local",
+            "foo-app.test.svc.cluster.local",
+        ),
+        (
+            "foo-app-0.foo-app-headless.test.svc.custom.domain",
+            "foo-app.test.svc.custom.domain",
+        ),
+        (
+            "foo-app-0.foo-app-headless.test.svc.custom.svc.domain",
+            "foo-app.test.svc.custom.svc.domain",
+        ),
+        ("localhost", "localhost"),
+        ("my.custom.domain", "my.custom.domain"),
+        ("192.0.2.1", "192.0.2.1"),
     ),
 )
 def test_app_hostname(

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -60,14 +60,14 @@ def test_no_roles_error():
 @pytest.mark.parametrize(
     "roles_active, roles_inactive, expected",
     (
-            (
-                    ["read", "write", "ingester", "all"],
-                    ["alertmanager"],
-                    ["read", "write", "ingester", "all"],
-            ),
-            (["read", "write"], ["alertmanager"], ["read", "write"]),
-            (["read"], ["alertmanager", "write", "ingester", "all"], ["read"]),
-            ([], ["read", "write", "ingester", "all", "alertmanager"], []),
+        (
+            ["read", "write", "ingester", "all"],
+            ["alertmanager"],
+            ["read", "write", "ingester", "all"],
+        ),
+        (["read", "write"], ["alertmanager"], ["read", "write"]),
+        (["read"], ["alertmanager", "write", "ingester", "all"], ["read"]),
+        ([], ["read", "write", "ingester", "all", "alertmanager"], []),
     ),
 )
 def test_roles_from_config(roles_active, roles_inactive, expected):
@@ -298,23 +298,23 @@ def test_worker_raises_if_service_restart_fails_for_too_long(tmp_path):
 @pytest.mark.parametrize(
     "remote_databag, expected",
     (
-            (
-                    {
-                        "remote_write_endpoints": json.dumps([{"url": "test-url.com"}]),
-                        "worker_config": json.dumps("test"),
-                    },
-                    [{"url": "test-url.com"}],
-            ),
-            ({"remote_write_endpoints": json.dumps(None), "worker_config": json.dumps("test")}, []),
-            (
-                    {
-                        "remote_write_endpoints": json.dumps(
-                            [{"url": "test-url.com"}, {"url": "test2-url.com"}]
-                        ),
-                        "worker_config": json.dumps("test"),
-                    },
-                    [{"url": "test-url.com"}, {"url": "test2-url.com"}],
-            ),
+        (
+            {
+                "remote_write_endpoints": json.dumps([{"url": "test-url.com"}]),
+                "worker_config": json.dumps("test"),
+            },
+            [{"url": "test-url.com"}],
+        ),
+        ({"remote_write_endpoints": json.dumps(None), "worker_config": json.dumps("test")}, []),
+        (
+            {
+                "remote_write_endpoints": json.dumps(
+                    [{"url": "test-url.com"}, {"url": "test2-url.com"}]
+                ),
+                "worker_config": json.dumps("test"),
+            },
+            [{"url": "test-url.com"}, {"url": "test2-url.com"}],
+        ),
     ),
 )
 def test_get_remote_write_endpoints(remote_databag, expected):
@@ -840,17 +840,17 @@ def test_invalid_url(mock_socket_fqdn):
 @pytest.mark.parametrize(
     "remote_databag, expected",
     (
-            (
-                    {
-                        "charm_tracing_receivers": json.dumps({"url": "test-url.com"}),
-                        "worker_config": json.dumps("test"),
-                    },
-                    {"url": "test-url.com"},
-            ),
-            (
-                    {"charm_tracing_receivers": json.dumps(None), "worker_config": json.dumps("test")},
-                    {},
-            ),
+        (
+            {
+                "charm_tracing_receivers": json.dumps({"url": "test-url.com"}),
+                "worker_config": json.dumps("test"),
+            },
+            {"url": "test-url.com"},
+        ),
+        (
+            {"charm_tracing_receivers": json.dumps(None), "worker_config": json.dumps("test")},
+            {},
+        ),
     ),
 )
 def test_get_charm_tracing_receivers(remote_databag, expected):
@@ -929,24 +929,29 @@ def test_charm_tracing_config(tls):
     )
     container = testing.Container(
         "foo",
-        execs={
-            testing.Exec(("update-ca-certificates", "--fresh"))
-        },
+        execs={testing.Exec(("update-ca-certificates", "--fresh"))},
         can_connect=True,
     )
     mock_certs_data = json.dumps("<TLS_STUFF>")
 
-    secret=Secret({"private-key": "verysecret"})
-    tls_data = {       "ca_cert": mock_certs_data,
-                "server_cert": mock_certs_data,
-                "privkey_secret_id": json.dumps(secret.id),
-        } if tls else {}
+    secret = Secret({"private-key": "verysecret"})
+    tls_data = (
+        {
+            "ca_cert": mock_certs_data,
+            "server_cert": mock_certs_data,
+            "privkey_secret_id": json.dumps(secret.id),
+        }
+        if tls
+        else {}
+    )
     relation = testing.Relation(
         "cluster",
         remote_app_data={
-            "charm_tracing_receivers": json.dumps({"otlp_http": f"http{'s' if tls else ''}://some-url"}),
+            "charm_tracing_receivers": json.dumps(
+                {"otlp_http": f"http{'s' if tls else ''}://some-url"}
+            ),
             "worker_config": json.dumps("test"),
-            **tls_data
+            **tls_data,
         },
     )
 
@@ -954,29 +959,31 @@ def test_charm_tracing_config(tls):
     with patch("ops_tracing.set_destination") as p:
         ctx.run(
             ctx.on.update_status(),
-            testing.State(containers={container},
-                          secrets={secret} if tls else {},
-                          relations={relation}),
+            testing.State(
+                containers={container}, secrets={secret} if tls else {}, relations={relation}
+            ),
         )
 
     # THEN set_destination gets called with the expected data
-    p.assert_called_with(url=f"http{'s' if tls else ''}://some-url/v1/traces", ca="<TLS_STUFF>" if tls else None)
+    p.assert_called_with(
+        url=f"http{'s' if tls else ''}://some-url/v1/traces", ca="<TLS_STUFF>" if tls else None
+    )
 
 
 @pytest.mark.parametrize(
     "remote_databag, expected",
     (
-            (
-                    {
-                        "workload_tracing_receivers": json.dumps({"url": "test-url.com"}),
-                        "worker_config": json.dumps("test"),
-                    },
-                    {"url": "test-url.com"},
-            ),
-            (
-                    {"workload_tracing_receivers": json.dumps(None), "worker_config": json.dumps("test")},
-                    {},
-            ),
+        (
+            {
+                "workload_tracing_receivers": json.dumps({"url": "test-url.com"}),
+                "worker_config": json.dumps("test"),
+            },
+            {"url": "test-url.com"},
+        ),
+        (
+            {"workload_tracing_receivers": json.dumps(None), "worker_config": json.dumps("test")},
+            {},
+        ),
     ),
 )
 def test_get_workload_tracing_receivers(remote_databag, expected):
@@ -1017,10 +1024,10 @@ def test_get_workload_tracing_receivers(remote_databag, expected):
 @pytest.mark.parametrize(
     "event",
     (
-            CharmEvents.update_status(),
-            CharmEvents.start(),
-            CharmEvents.install(),
-            CharmEvents.relation_changed,
+        CharmEvents.update_status(),
+        CharmEvents.start(),
+        CharmEvents.install(),
+        CharmEvents.relation_changed,
     ),
 )
 def test_worker_blocks_on_tls_misconfigured(event):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -92,14 +92,14 @@ def test_roles_from_config(roles_active, roles_inactive, expected):
 
     # AND the charm runs with a few of those set to true, the rest to false
     with ctx(
-            ctx.on.update_status(),
-            testing.State(
-                containers={testing.Container("foo")},
-                config={
-                    **{f"role-{r}": False for r in roles_inactive},
-                    **{f"role-{r}": True for r in roles_active},
-                },
-            ),
+        ctx.on.update_status(),
+        testing.State(
+            containers={testing.Container("foo")},
+            config={
+                **{f"role-{r}": False for r in roles_inactive},
+                **{f"role-{r}": True for r in roles_active},
+            },
+        ),
     ) as mgr:
         # THEN the Worker.roles method correctly returns the list of only those that are set to true
         assert set(mgr.charm.worker.roles) == set(expected)
@@ -337,8 +337,8 @@ def test_get_remote_write_endpoints(remote_databag, expected):
         remote_app_data=remote_databag,
     )
     with ctx(
-            ctx.on.relation_changed(relation),
-            testing.State(containers={container}, relations={relation}),
+        ctx.on.relation_changed(relation),
+        testing.State(containers={container}, relations={relation}),
     ) as mgr:
         charm = mgr.charm
         mgr.run()
@@ -894,8 +894,8 @@ def test_get_charm_tracing_receivers(remote_databag, expected):
 
     # WHEN the relation changes
     with ctx(
-            ctx.on.relation_changed(relation),
-            testing.State(containers={container}, relations={relation}),
+        ctx.on.relation_changed(relation),
+        testing.State(containers={container}, relations={relation}),
     ) as mgr:
         charm = mgr.charm
         # THEN the charm tracing receivers are picked up correctly
@@ -1006,8 +1006,8 @@ def test_get_workload_tracing_receivers(remote_databag, expected):
 
     # WHEN the relation changes
     with ctx(
-            ctx.on.relation_changed(relation),
-            testing.State(containers={container}, relations={relation}),
+        ctx.on.relation_changed(relation),
+        testing.State(containers={container}, relations={relation}),
     ) as mgr:
         charm = mgr.charm
         # THEN the charm tracing receivers are picked up correctly

--- a/tests/unit/test_worker_status.py
+++ b/tests/unit/test_worker_status.py
@@ -135,9 +135,7 @@ def endpoint_ready(tls):
 
 @contextmanager
 def config_on_disk():
-    with patch(
-        "coordinated_workers.worker.Worker._running_worker_config", new=lambda _: True
-    ):
+    with patch("coordinated_workers.worker.Worker._running_worker_config", new=lambda _: True):
         yield
 
 
@@ -159,9 +157,7 @@ def test_status_check_no_pebble(ctx, base_state, caplog):
 def test_status_check_no_config(ctx, base_state, caplog):
     # GIVEN there is no config file on disk
     # WHEN we run any event
-    with patch(
-        "coordinated_workers.worker.Worker._running_worker_config", new=lambda _: None
-    ):
+    with patch("coordinated_workers.worker.Worker._running_worker_config", new=lambda _: None):
         state_out = ctx.run(ctx.on.update_status(), base_state)
 
     # THEN the charm sets blocked

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 [testenv:fmt]
 description = "Format the code"
 commands =
-    uv run {[vars]uv_flags} --all-extras ruff check --fix-only {[vars]all_path}
+    uv run {[vars]uv_flags} --all-extras ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Lint the code

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "coordinated-workers"
-version = "0.0.3"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cosl" },
@@ -169,7 +169,7 @@ dependencies = [
     { name = "jsonschema", version = "4.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "jsonschema", version = "4.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "lightkube" },
-    { name = "ops" },
+    { name = "ops", extra = ["tracing"] },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -194,8 +194,8 @@ requires-dist = [
     { name = "cryptography" },
     { name = "jsonschema" },
     { name = "lightkube", specifier = ">=0.15.4" },
-    { name = "ops" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
+    { name = "ops", extras = ["tracing"] },
     { name = "pydantic" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -685,6 +685,33 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-sdk"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/12/909b98a7d9b110cce4b28d49b2e311797cffdce180371f35eba13a72dd00/opentelemetry_sdk-1.33.1.tar.gz", hash = "sha256:85b9fcf7c3d23506fbc9692fd210b8b025a1920535feec50bd54ce203d57a531", size = 161885, upload-time = "2025-05-16T18:52:52.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/8e/ae2d0742041e0bd7fe0d2dcc5e7cce51dcf7d3961a26072d5b43cc8fa2a7/opentelemetry_sdk-1.33.1-py3-none-any.whl", hash = "sha256:19ea73d9a01be29cacaa5d6c8ce0adc0b7f7b4d58cc52f923e4413609f670112", size = 118950, upload-time = "2025-05-16T18:52:37.297Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/2c/d7990fc1ffc82889d466e7cd680788ace44a26789809924813b164344393/opentelemetry_semantic_conventions-0.54b1.tar.gz", hash = "sha256:d1cecedae15d19bdaafca1e56b29a66aa286f50b5d08f036a145c7f3e9ef9cee", size = 118642, upload-time = "2025-05-16T18:52:53.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/80/08b1698c52ff76d96ba440bf15edc2f4bc0a279868778928e947c1004bdd/opentelemetry_semantic_conventions-0.54b1-py3-none-any.whl", hash = "sha256:29dab644a7e435b58d3a3918b58c333c92686236b30f7891d5e51f02933ca60d", size = 194938, upload-time = "2025-05-16T18:52:38.796Z" },
+]
+
+[[package]]
 name = "ops"
 version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -704,6 +731,9 @@ wheels = [
 testing = [
     { name = "ops-scenario" },
 ]
+tracing = [
+    { name = "ops-tracing" },
+]
 
 [[package]]
 name = "ops-scenario"
@@ -716,6 +746,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/65/13f60a4f0ba54f6731733ece46e98276fef62c48b62f80c1a9501f46f28f/ops_scenario-7.22.0.tar.gz", hash = "sha256:15921e6849773b81df90ad4d78f573e0af5f5b9ddbfc82603c991c29648d8070", size = 142308, upload-time = "2025-05-29T04:18:49.194Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/9c/1abc3c03a27eccb2580df035a78e0115c1dc29f6f379c9465990f69d0913/ops_scenario-7.22.0-py3-none-any.whl", hash = "sha256:a42d3acf831fc46f213286268e31d14c2ffc5ea72452c49955de76895f62437c", size = 72506, upload-time = "2025-05-29T04:18:46.657Z" },
+]
+
+[[package]]
+name = "ops-tracing"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+    { name = "ops" },
+    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6b/00dbf4ef4d477817dd129c45497c1fee330e2465735318595eae3d8d6ade/ops_tracing-2.22.0.tar.gz", hash = "sha256:238ede5e9268f81deefce9275d2c846bd2726f1bf17f2f74bdf07432d147f2cd", size = 28191, upload-time = "2025-05-29T04:18:44.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/5b/b0f11278f19bfd8250a52d837cf38a29d78e1200610becdf70a9cc20ab5a/ops_tracing-2.22.0-py3-none-any.whl", hash = "sha256:f47bf9fd35e47bab2499de7428bc2433534e6331ff6ec1ab533f31a48b1341f4", size = 31245, upload-time = "2025-05-29T04:18:43.168Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds built-in charm tracing to Worker and Coordinator.
All coordinated-workers charms will inherit it and will need to simply remove any dependency from charm_tracing for it to work.

Upgrade steps:
- remove `charm_tracing` (charm library and all references)