### PR TITLE
Bump version to `2.0.0` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "1.0.0"
+version = "2.0.0"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ wheels = [
 
 [[package]]
 name = "coordinated-workers"
-version = "1.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cosl" },


### PR DESCRIPTION
Before https://github.com/canonical/cos-coordinated-workers/pull/13 was merged, the latest version published on PyPi was `1.0.1` while the version file had `0.1.0`.

Now that it's merged and it introduced yet another breaking change, we should bump the major version to `2.0.0`
