### PR TITLE
fix: remove unused grafana_source lib references

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -46,7 +46,6 @@ from coordinated_workers.nginx import (
 
 check_libs_installed(
     "charms.data_platform_libs.v0.s3",
-    "charms.grafana_k8s.v0.grafana_source",
     "charms.grafana_k8s.v0.grafana_dashboard",
     "charms.prometheus_k8s.v0.prometheus_scrape",
     "charms.loki_k8s.v1.loki_push_api",

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ allowlist_externals = charmcraft
 commands =
     # fetch all charm libs required by the coordinated_workers package
     charmcraft fetch-lib charms.data_platform_libs.v0.s3
-    charmcraft fetch-lib charms.grafana_k8s.v0.grafana_source
     charmcraft fetch-lib charms.grafana_k8s.v0.grafana_dashboard
     charmcraft fetch-lib charms.prometheus_k8s.v0.prometheus_scrape
     charmcraft fetch-lib charms.loki_k8s.v1.loki_push_api


### PR DESCRIPTION
The coordinator checks that the grafana_source charm lib is present, but does not in fact use it in any way.
This PR removes the lib and all references from the coordinator's charm lib requirement list.

Fixes #28 