### PR TITLE
fix: be more careful in accessing unit databag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "2.0.5"
+version = "2.0.6"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -586,7 +586,7 @@ class Coordinator(ops.Object):
         # get unit addresses for all the other units from a databag
         addresses = []
         if peers and relation:
-            addresses = [relation.data[unit].get("local-ip") for unit in peers]
+            addresses = [relation.data.get(unit, {}).get("local-ip") for unit in peers]
             addresses = list(filter(None, addresses))
 
         # add own address
@@ -748,9 +748,10 @@ class Coordinator(ops.Object):
 
         for relation in relations:
             for unit in relation.units:
-                if "endpoint" not in relation.data[unit]:
+                unit_databag = relation.data.get(unit, {})
+                if "endpoint" not in unit_databag:
                     continue
-                endpoint = relation.data[unit]["endpoint"]
+                endpoint = unit_databag["endpoint"]
                 deserialized_endpoint = json.loads(endpoint)
                 url = deserialized_endpoint["url"]
                 endpoints[unit.name] = url


### PR DESCRIPTION
Due to an unknown issue (probably a juju bug or 3.6+ regression), sometimes `relation-get` fails on certain units when attempting to read relation unit data.

This PR adds safety guards in a couple of Coordinator codepaths that do that.
