### PR TITLE
fix: turn `app_hostname` into a staticmethod

### DIFF
--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -587,10 +587,12 @@ def test_app_hostname(
 
     # WHEN any event fires
     with ctx(ctx.on.update_status(), testing.State(model=testing.Model("test"))) as mgr:
-        with patch("coordinated_workers.coordinator.Coordinator.hostname", hostname):
-            # THEN if hostname is a valid k8s pod fqdn, app_hostname is set to the k8s service fqdn
-            # else app_hostname is set to whatever value hostname has
-            assert mgr.charm.coordinator.app_hostname == expected_app_hostname
+        # THEN if hostname is a valid k8s pod fqdn, app_hostname is set to the k8s service fqdn
+        # else app_hostname is set to whatever value hostname has
+        assert (
+            mgr.charm.coordinator.app_hostname(hostname, mgr.charm.app.name, mgr.charm.model.name)
+            == expected_app_hostname
+        )
 
 
 def test_catalogue_integration(coordinator_state: testing.State):
@@ -678,6 +680,8 @@ def test_catalogue_integration(coordinator_state: testing.State):
     # THEN the coordinator has published his catalogue item
     catalogue_relation_out = state_out.get_relation(catalogue_relation.id)
     assert catalogue_relation_out.local_app_data
+
+
 @contextmanager
 def patch_source_alert_rules():
     resources_base_path = Path(__file__).parent / "resources"


### PR DESCRIPTION
## Issue
We have to duplicate code in the pyroscope coordinator because we can't use the logic contained in the `Coordinator.app_hostname` property.

Cfr. https://github.com/canonical/tempo-operators/pull/140#pullrequestreview-3074539737

This PR turns it into a staticmethod, so we can use it from anywhere.
It's technically a breaking API change since `app_hostname` is public, but I checked that it isn't used anywhere in loki, mimir, tempo or pyroscope so it shouldn't cause any breakage.