### PR TITLE
fix: consolidate rules error on mkdir

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -847,7 +847,7 @@ class Coordinator(ops.Object):
                 CONSOLIDATED_METRICS_ALERT_RULES_PATH,
                 CONSOLIDATED_LOGS_ALERT_RULES_PATH,
             ):
-                path.mkdir(exist_ok=True)
+                path.mkdir(exist_ok=True, parents=True)
                 self._remove_consolidated_alert_rules(path)
             self._consolidate_workers_alert_rules()
             self._consolidate_nginx_alert_rules()


### PR DESCRIPTION
I'm getting errors in unittests in pyroscope:

```
    custom_handler(event)
../../.venv/lib/python3.12/site-packages/coordinated_workers/coordinator.py:402: in _on_any_event
    self._reconcile()
../../.venv/lib/python3.12/site-packages/coordinated_workers/coordinator.py:424: in _reconcile
    self._consolidate_alert_rules()
../../.venv/lib/python3.12/site-packages/coordinated_workers/coordinator.py:850: in _consolidate_alert_rules
    path.mkdir(exist_ok=True)
```

we should probably add `parents=True` to the mkdir call there.

TODO: add unittest coverage