### PR TITLE
feat: juju proxy envvar passthrough

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "2.0.8"
+version = "2.0.9"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -620,9 +620,7 @@ class NginxConfig:
 
     def _listen(self, port: int, ssl: bool, http2: bool) -> List[Dict[str, Any]]:
         directives: List[Dict[str, Any]] = []
-        directives.append(
-            {"directive": "listen", "args": self._listen_args(port, False, ssl)}
-        )
+        directives.append({"directive": "listen", "args": self._listen_args(port, False, ssl)})
         if self._ipv6_enabled:
             directives.append(
                 {
@@ -631,9 +629,7 @@ class NginxConfig:
                 }
             )
         if http2:
-            directives.append(
-                {"directive": "http2", "args": ["on"]}
-            )
+            directives.append({"directive": "http2", "args": ["on"]})
         return directives
 
     def _listen_args(self, port: int, ipv6: bool, ssl: bool) -> List[str]:

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -459,7 +459,7 @@ class Worker(ops.Object):
     @staticmethod
     def _add_proxy_info(new_layer: Layer):
         """Add juju proxy envvars to all services a pebble layer."""
-        for svc_name, svc_spec in new_layer.services.items():
+        for svc_spec in new_layer.services.values():
             svc_spec.environment.update(
                 {
                     "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -4,6 +4,7 @@
 """Generic worker for a distributed charm deployment."""
 
 import logging
+import os
 import re
 import socket
 import subprocess
@@ -439,6 +440,7 @@ class Worker(ops.Object):
             return False
 
         self._add_readiness_check(layer)
+        self._add_proxy_info(layer)
 
         def diff(layer: Layer, plan: Plan):
             layer_dct = layer.to_dict()
@@ -453,6 +455,18 @@ class Worker(ops.Object):
             self._container.add_layer(self._name, layer, combine=True)
             return True
         return False
+
+    @staticmethod
+    def _add_proxy_info(new_layer: Layer):
+        """Add juju proxy envvars to all services a pebble layer."""
+        for svc_name, svc_spec in new_layer.services.items():
+            svc_spec.environment.update(
+                {
+                    "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+                    "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+                    "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+                }
+            )
 
     def _add_readiness_check(self, new_layer: Layer):
         """Add readiness check to a pebble layer."""


### PR DESCRIPTION
This is a blocker for COS HA testing on ps7
All components that talk to s3 must set a few envvars in their pebble layers.

[See issue in tempo](https://github.com/canonical/tempo-operators/issues/44)
[see similar PR in grafana](https://github.com/canonical/grafana-k8s-operator/blob/0a91c1528ec98cbcefe74bbc84e8b74aff0e410b/src/charm.py#L1060)

This does the same for all worker charms.