### PR TITLE
fix: inject uppercase versions of all proxy envvars as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "2.0.9"
+version = "2.0.10"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/worker.py
+++ b/src/coordinated_workers/worker.py
@@ -460,13 +460,13 @@ class Worker(ops.Object):
     def _add_proxy_info(new_layer: Layer):
         """Add juju proxy envvars to all services a pebble layer."""
         for svc_spec in new_layer.services.values():
-            svc_spec.environment.update(
-                {
-                    "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-                    "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-                    "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
-                }
-            )
+            for source, dest in (
+                ("JUJU_CHARM_HTTPS_PROXY", "https_proxy"),
+                ("JUJU_CHARM_HTTP_PROXY", "http_proxy"),
+                ("JUJU_CHARM_NO_PROXY", "no_proxy"),
+            ):
+                if value_set := os.environ.get(source, None):
+                    svc_spec.environment.update({dest.upper(): value_set, dest: value_set})
 
     def _add_readiness_check(self, new_layer: Layer):
         """Add readiness check to a pebble layer."""


### PR DESCRIPTION
Alex Micouleau pointed out that some workloads only read full-uppercase proxy envvars, so it's better safe than sorry to inject both lower and uppercase proxy envvars.

Docs on the matter are scarce but it seems that at least pyroscope supports both https://grafana.com/docs/agent/latest/flow/reference/components/pyroscope.write/

