### PR TITLE
feat: Allow specifying root path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "2.0.10"
+version = "2.0.11"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -307,18 +307,27 @@ class NginxConfig:
         self._dns_IP_address = self._get_dns_ip_address()
         self._ipv6_enabled = is_ipv6_enabled()
 
-    def get_config(self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool, root_path: Optional[str] = None) -> str:
+    def get_config(
+        self,
+        upstreams_to_addresses: Dict[str, Set[str]],
+        listen_tls: bool,
+        root_path: Optional[str] = None,
+    ) -> str:
         """Render the Nginx configuration as a string.
 
         Args:
             upstreams_to_addresses: A dictionary mapping each upstream name to a set of addresses associated with that upstream.
             listen_tls: Whether Nginx should listen for incoming traffic over TLS.
+            root_path: If provided, it is used as a location where static files will be served.
         """
         full_config = self._prepare_config(upstreams_to_addresses, listen_tls, root_path)
         return crossplane.build(full_config)  # type: ignore
 
     def _prepare_config(
-        self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool, root_path: Optional[str] = None
+        self,
+        upstreams_to_addresses: Dict[str, Set[str]],
+        listen_tls: bool,
+        root_path: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         upstreams = self._upstreams(upstreams_to_addresses)
         # extract the upstream name
@@ -483,7 +492,7 @@ class NginxConfig:
         locations: List[NginxLocationConfig],
         backends: List[str],
         listen_tls: bool = False,
-        root_path: Optional[str] = None
+        root_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         auth_enabled = False
         is_grpc = any(loc.is_grpc for loc in locations)
@@ -610,12 +619,10 @@ class NginxConfig:
                 )
 
         return nginx_locations
-    
+
     def _root_path(self, root_path: Optional[str] = None) -> List[Optional[Dict[str, Any]]]:
         if root_path:
-            return [
-                {"directive": "root", "args": [root_path]}
-            ]
+            return [{"directive": "root", "args": [root_path]}]
         return []
 
     def _basic_auth(self, enabled: bool) -> List[Optional[Dict[str, Any]]]:

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -260,6 +260,7 @@ class NginxConfig:
     _pid = "/tmp/nginx.pid"
     _worker_rlimit_nofile = "8192"
     _worker_connections = "4096"
+    _worker_connections = "4096"
     _proxy_read_timeout = "300"
     _supported_tls_versions = ["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]
     _ssl_ciphers = ["HIGH:!aNULL:!MD5"]
@@ -306,18 +307,18 @@ class NginxConfig:
         self._dns_IP_address = self._get_dns_ip_address()
         self._ipv6_enabled = is_ipv6_enabled()
 
-    def get_config(self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool) -> str:
+    def get_config(self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool, root_path: Optional[str] = None) -> str:
         """Render the Nginx configuration as a string.
 
         Args:
             upstreams_to_addresses: A dictionary mapping each upstream name to a set of addresses associated with that upstream.
             listen_tls: Whether Nginx should listen for incoming traffic over TLS.
         """
-        full_config = self._prepare_config(upstreams_to_addresses, listen_tls)
+        full_config = self._prepare_config(upstreams_to_addresses, listen_tls, root_path)
         return crossplane.build(full_config)  # type: ignore
 
     def _prepare_config(
-        self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool
+        self, upstreams_to_addresses: Dict[str, Set[str]], listen_tls: bool, root_path: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         upstreams = self._upstreams(upstreams_to_addresses)
         # extract the upstream name
@@ -372,7 +373,7 @@ class NginxConfig:
                     },
                     {"directive": "proxy_read_timeout", "args": [self._proxy_read_timeout]},
                     # server block
-                    *self._build_servers_config(backends, listen_tls),
+                    *self._build_servers_config(backends, listen_tls, root_path),
                 ],
             },
         ]
@@ -461,7 +462,7 @@ class NginxConfig:
         return nginx_upstreams
 
     def _build_servers_config(
-        self, backends: List[str], listen_tls: bool = False
+        self, backends: List[str], listen_tls: bool = False, root_path: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         servers: List[Dict[str, Any]] = []
         for port, locations in self._server_ports_to_locations.items():
@@ -470,6 +471,7 @@ class NginxConfig:
                 locations,
                 backends,
                 listen_tls,
+                root_path,
             )
             if server_config:
                 servers.append(server_config)
@@ -481,6 +483,7 @@ class NginxConfig:
         locations: List[NginxLocationConfig],
         backends: List[str],
         listen_tls: bool = False,
+        root_path: Optional[str] = None
     ) -> Dict[str, Any]:
         auth_enabled = False
         is_grpc = any(loc.is_grpc for loc in locations)
@@ -492,6 +495,7 @@ class NginxConfig:
                 "args": [],
                 "block": [
                     *self._listen(port, ssl=listen_tls, http2=is_grpc),
+                    *self._root_path(root_path),
                     *self._basic_auth(auth_enabled),
                     {
                         "directive": "proxy_set_header",
@@ -606,6 +610,13 @@ class NginxConfig:
                 )
 
         return nginx_locations
+    
+    def _root_path(self, root_path: Optional[str] = None) -> List[Optional[Dict[str, Any]]]:
+        if root_path:
+            return [
+                {"directive": "root", "args": [root_path]}
+            ]
+        return []
 
     def _basic_auth(self, enabled: bool) -> List[Optional[Dict[str, Any]]]:
         if enabled:

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -260,7 +260,6 @@ class NginxConfig:
     _pid = "/tmp/nginx.pid"
     _worker_rlimit_nofile = "8192"
     _worker_connections = "4096"
-    _worker_connections = "4096"
     _proxy_read_timeout = "300"
     _supported_tls_versions = ["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]
     _ssl_ciphers = ["HIGH:!aNULL:!MD5"]

--- a/tests/unit/resources/sample_tempo_nginx_conf_root_path.txt
+++ b/tests/unit/resources/sample_tempo_nginx_conf_root_path.txt
@@ -1,0 +1,144 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream zipkin {
+        zone zipkin_zone 64k;
+        server worker-address:9411 resolve;
+    }
+    upstream otlp-grpc {
+        zone otlp-grpc_zone 64k;
+        server worker-address:4317 resolve;
+    }
+    upstream otlp-http {
+        zone otlp-http_zone 64k;
+        server worker-address:4318 resolve;
+    }
+    upstream jaeger-thrift-http {
+        zone jaeger-thrift-http_zone 64k;
+        server worker-address:14268 resolve;
+    }
+    upstream jaeger-grpc {
+        zone jaeger-grpc_zone 64k;
+        server worker-address:14250 resolve;
+    }
+    upstream tempo-http {
+        zone tempo-http_zone 64k;
+        server worker-address:3200 resolve;
+    }
+    upstream tempo-grpc {
+        zone tempo-grpc_zone 64k;
+        server worker-address:9096 resolve;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 9411;
+        listen [::]:9411;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://zipkin;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4317;
+        listen [::]:4317;
+        http2 on;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://otlp-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4318;
+        listen [::]:4318;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://otlp-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14268;
+        listen [::]:14268;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://jaeger-thrift-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14250;
+        listen [::]:14250;
+        http2 on;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://jaeger-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 3200;
+        listen [::]:3200;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://tempo-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 9096;
+        listen [::]:9096;
+        http2 on;
+        root /dist;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://tempo-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In litmus development, we wanted to use the `Nginx` object from coordinated-workers. It proved to be usable, but for Litmus we need to specify the root path where static files are served.


## Solution
<!-- A summary of the solution addressing the above issue -->
Allow `root_path` to be passed as a parameter in `get_config`

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
New test should cover it. The old existing tests show backward compatibility of the change.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
