### PR TITLE
feat: make active status messages configurable

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -202,6 +202,9 @@ class Coordinator(ops.Object):
     running Nginx, and implementing self-monitoring integrations.
     """
 
+    _default_degraded_message = "Degraded."
+    _default_active_message = ""
+
     def __init__(
         self,
         charm: ops.CharmBase,
@@ -700,7 +703,7 @@ class Coordinator(ops.Object):
             statuses.append(ops.BlockedStatus("[consistency] Cluster inconsistent."))
         elif not self.is_recommended:
             # if is_recommended is None: it means we don't meet the recommended deployment criterion.
-            statuses.append(ops.ActiveStatus("Degraded."))
+            statuses.append(ops.ActiveStatus(self._default_degraded_message))
 
         if not self.s3_requirer.relations:
             statuses.append(ops.BlockedStatus("[s3] Missing S3 integration."))
@@ -717,7 +720,7 @@ class Coordinator(ops.Object):
             )
 
         if not statuses:
-            statuses.append(ops.ActiveStatus())
+            statuses.append(ops.ActiveStatus(self._default_active_message))
 
         for status in statuses:
             e.add_status(status)


### PR DESCRIPTION
We want pyroscope to display its UI address in its active status message like parca does (and traefik for its ingress URL).

With this change, we can do:

```
class PyroscopeCharm(...)
    def  __init__(...):
        self.coordinator = PyroscopeCoordinator(..., active_status_msg = f"UI ready at socket.getfqdn():8080")  # or something similar

class PyroscopeCoordinator(coordinated_workers.Coordinator):
     def  __init__(..., active_status_msg):
        super().__init__(**...)
        self._default_active_status_msg = active_status_msg
```

The alternative, hackier approach would be to do this in Pyroscope:

```
class PyroscopeCoordinator(coordinated_workers.Coordinator):
     def  __init__(..., active_status_msg):
          self.coordinator = Coordinator(...)

          # register it after instantiating Coordinator, so it's executed AFTER 
          self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)

    def _on_collect_unit_status(self, e: ops.CollectStatusEvent):
        collected_statuses = self.unit._collected_statuses
        if len(collected_statuses) == 1:
            status = collected_statuses.pop()
            if isinstance(status, ops.ActiveStatus):  # do not override blocked/waiting, only Active. With or without "Degraded."
                e.add_status(ops.ActiveStatus("foo"))
            else:
                # add it back, with many excuses
                e.add_status(status)
```