### PR TITLE
Use `*.svc.cluster.local` wildcard as the CN

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -661,7 +661,7 @@ class Coordinator(ops.Object):
     def _certificate_request_attributes(self) -> CertificateRequestAttributes:
         return CertificateRequestAttributes(
             # common_name is deprecated but often still required in the wild, and is actually required by the TLS lib:
-            # https://github.com/canonical/tls-certificates-interface/issues/369
+            # TODO: drop common_name arg (https://github.com/canonical/tls-certificates-interface/issues/369).
             # It is also limited to 64 chars, so cannot always use socket.getfqdn().
             # We cannot use a constrained name such as self._charm.app.name, because Let's Encrypt complains:
             # "Domain name needs at least one dot".


### PR DESCRIPTION
## Issue
CN is deprecated, but the TLS charmlib requires it
https://github.com/canonical/tls-certificates-interface/issues/369

Currently we set it as the app name, but that is invalid because the CN must be derived from the SANs DNS.
Let's Encrypt complains (via Lego charm):

> An error occurred executing the lego command: error: couldn't request certificate: coudn't obtain cert: acme: error: 400 :: POST :: https://acme-v02.api.letsencrypt.org/acme/new-order :: urn:ietf:params:acme:error:rejectedIdentifier :: Invalid identifiers requested :: Cannot issue for "mimir": Domain name needs at least one dot

> "urn:ietf:params:acme:error:malformed" :: Invalid identifiers requested :: Domain name does not end with a valid public suffix (TLD).

We cannot use `socket.getfqdn()` because it's too long.
https://community.letsencrypt.org/t/simplifying-issuance-for-very-long-domain-names/207924


## Solution
Use a (silly) wildcard, `*.svc.cluster.local`.

Very different circumstances, but google practices the same.
<img width="835" height="723" alt="image" src="https://github.com/user-attachments/assets/1ad042e9-d834-43db-b026-e4e7b02e9f13" />



## Context
Mimir, Loki, Tempo charms do not have an analogue to traefik's [`external_hostname`](https://github.com/canonical/traefik-k8s-operator/blob/fcdc424b7eedea883661412b9c6a4241af9614f6/config.yaml#L33) config option, meaning they currently cannot obtain a cert from e.g. Let's Encrypt. Only internal CA. So the `*.local` should be safe for now.

If we keep using self-signed-certificates, then this PR is not needed, because that "CA" is very permissive. But for a more strict internal CA this is probably a good change.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
