### PR TITLE
feat[DRAFT DONT REVIEW: route metrics traffic via nginx

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -305,7 +305,9 @@ class Coordinator(ops.Object):
         if self._route_worker_metrics:
             worker_topology = self.cluster.gather_topology()
             if worker_topology:
-                worker_upstreams, worker_locations = self._generate_worker_metrics_nginx_config(worker_topology)
+                worker_upstreams, worker_locations = self._generate_worker_metrics_nginx_config(
+                    worker_topology
+                )
                 nginx_config.extend_upstream_configs(worker_upstreams)
                 nginx_config.update_server_ports_to_locations(worker_locations, overwrite=False)
 
@@ -633,7 +635,9 @@ class Coordinator(ops.Object):
         for worker_topology in self.cluster.gather_topology():
             if self._route_worker_metrics:
                 # Route worker metrics through nginx proxy
-                targets = [f"{self.hostname}:{self._worker_metrics_port}/workers/{worker_topology['unit'].replace('/', '-')}"]
+                targets = [
+                    f"{self.hostname}:{self._worker_metrics_port}/workers/{worker_topology['unit'].replace('/', '-')}"
+                ]
             else:
                 # Direct access to worker metrics endpoints
                 targets = [f"{worker_topology['address']}:{self._worker_metrics_port}"]
@@ -879,21 +883,25 @@ class Coordinator(ops.Object):
     def _generate_worker_metrics_nginx_config(self, worker_topology):
         """Generate nginx upstreams and locations for worker metrics routing."""
         upstreams = []
-        locations = {self._worker_metrics_port: []}
+        locations = {
+            self._worker_metrics_port: []
+        }
 
-        for worker in worker_topology:
-            unit_name = worker["unit"].replace("/", "-")
+        for worker_ in worker_topology:
+            unit_name = worker_["unit"].replace("/", "-")
             upstream_name = f"worker-metrics-{unit_name}"
 
             # Create upstream for this worker
-            upstreams.append(NginxUpstream(upstream_name, self._worker_metrics_port, upstream_name))
+            upstreams.append(
+                NginxUpstream(upstream_name, self._worker_metrics_port, upstream_name)
+            )
 
             # Route /workers/{unit}/metrics to upstream/metrics
             location = NginxLocationConfig(
                 path=f"/workers/{unit_name}/metrics",
                 backend=upstream_name,
                 backend_url="/metrics",
-                is_grpc=False
+                is_grpc=False,
             )
             locations[self._worker_metrics_port].append(location)
 

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -633,16 +633,20 @@ class Coordinator(ops.Object):
         scrape_jobs: List[Dict[str, Any]] = []
 
         for worker_topology in self.cluster.gather_topology():
+            # Direct access to worker metrics endpoints
+            targets = [f"{worker_topology['address']}:{self._worker_metrics_port}"]
+            metrics_path = "/metrics"
             if self._route_worker_metrics:
-                # Route worker metrics through nginx proxy
+                # when proxied through nginx
+                # adress: address of the coordinator
+                # path: location used in the nginx config for proxying worker metric
                 targets = [
-                    f"{self.hostname}:{self._worker_metrics_port}/workers/{worker_topology['unit'].replace('/', '-')}"
+                    f"{self.hostname}:{self._worker_metrics_port}"
                 ]
-            else:
-                # Direct access to worker metrics endpoints
-                targets = [f"{worker_topology['address']}:{self._worker_metrics_port}"]
+                metrics_path = f"/workers/{worker_topology['unit'].replace('/', '-')}"
 
             job = {
+                "metrics_path": metrics_path,
                 "static_configs": [
                     {
                         "targets": targets,

--- a/src/coordinated_workers/interfaces/cluster.py
+++ b/src/coordinated_workers/interfaces/cluster.py
@@ -301,6 +301,14 @@ class ClusterProvider(Object):
                     continue
         return data
 
+    def gather_addresses_by_unit(self) -> Dict[str, Set[str]]:
+        """Go through the worker's unit databags to collect addresses by individual unit."""
+        data: Dict[str, Set[str]] = {}
+        for worker in self.gather_topology():
+            unit_name = worker["unit"]
+            data[unit_name] = {worker["address"]}
+        return data
+
     def gather_addresses(self) -> Tuple[str, ...]:
         """Go through the worker's unit databags to collect all the addresses published by the units."""
         data: Set[str] = set()

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -232,7 +232,9 @@ class NginxLocationConfig:
     """Custom rewrite, used i.e. to drop the subpath from the proxied request if needed.
     Example: ['^/auth(/.*)$', '$1', 'break'] to drop `/auth` from the request.
     """
-    extra_directives: Dict[str, List[str]] = field(default_factory=lambda: cast(Dict[str, List[str]], {}))
+    extra_directives: Dict[str, List[str]] = field(
+        default_factory=lambda: cast(Dict[str, List[str]], {})
+    )
     """Dictionary of arbitrary location configuration keys and values.
     Example: {"proxy_ssl_verify": ["off"]}
     """
@@ -318,9 +320,11 @@ class NginxConfig:
         """Add upstreams to existing configuration."""
         self._upstream_configs.extend(upstream_configs)
 
-    def update_server_ports_to_locations(self,
-                                       server_ports_to_locations: Dict[int, List[NginxLocationConfig]],
-                                       overwrite: bool = True):
+    def update_server_ports_to_locations(
+        self,
+        server_ports_to_locations: Dict[int, List[NginxLocationConfig]],
+        overwrite: bool = True,
+    ):
         """Add locations to existing port configurations.
 
         Args:

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -251,13 +251,14 @@ class NginxUpstream:
 
     Our coordinators assume that all servers under an upstream share the same port.
     """
-    worker_role: str
-    """The worker role that corresponds to this upstream.
+    address_lookup_key: str
+    """The address lookup key that corresponds to this upstream.
 
-    This role will be used to look up workers (backend server) addresses for this upstream.
+    This key will be used to look up backend server addresses for this upstream.
+    Can be a worker role (e.g., 'compactor') or individual unit identifier (e.g., 'worker-metrics-unit-0').
     """
-    ignore_worker_role: bool = False
-    """If True, overrides `worker_role` and routes to all available backend servers.
+    ignore_address_lookup: bool = False
+    """If True, overrides `address_lookup_key` and routes to all available backend servers.
 
     Use this when the upstream should be generic and include any available backend.
     """
@@ -465,13 +466,13 @@ class NginxConfig:
         nginx_upstreams: List[Any] = []
 
         for upstream_config in self._upstream_configs:
-            if upstream_config.ignore_worker_role:
+            if upstream_config.ignore_address_lookup:
                 # include all available addresses
                 addresses: Optional[Set[str]] = set()
                 for address_set in upstreams_to_addresses.values():
                     addresses.update(address_set)
             else:
-                addresses = upstreams_to_addresses.get(upstream_config.worker_role)
+                addresses = upstreams_to_addresses.get(upstream_config.address_lookup_key)
 
             # don't add an upstream block if there are no addresses
             if addresses:

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -314,6 +314,27 @@ class NginxConfig:
         self._dns_IP_address = self._get_dns_ip_address()
         self._ipv6_enabled = is_ipv6_enabled()
 
+    def extend_upstream_configs(self, upstream_configs: List[NginxUpstream]):
+        """Add upstreams to existing configuration."""
+        self._upstream_configs.extend(upstream_configs)
+
+    def update_server_ports_to_locations(self,
+                                       server_ports_to_locations: Dict[int, List[NginxLocationConfig]],
+                                       overwrite: bool = True):
+        """Add locations to existing port configurations.
+
+        Args:
+            server_ports_to_locations: Dictionary mapping ports to location configs
+            overwrite: If True, replace existing locations for each port.
+                      If False, extend existing locations for each port.
+        """
+        for port, locations in server_ports_to_locations.items():
+            if overwrite or port not in self._server_ports_to_locations:
+                self._server_ports_to_locations[port] = locations.copy()
+            else:
+                # Extend existing locations for this port
+                self._server_ports_to_locations[port].extend(locations)
+
     def get_config(
         self,
         upstreams_to_addresses: Dict[str, Set[str]],


### PR DESCRIPTION
## Issue
Fixes #59 

# Solution
The base `Coordnator` class provides a boolean argument `proxy_worker_metrics` which when enabled adds the required nginx routes and passes the nginx proxy urls to the metrics scrapers instead of the direct worker addresses.

This allows the consumers of coordinated-workers to enable proxying of worker metrics in a simple way.

# Testing
Currently can be tested using one of the coordinated worker charms (Tempo, Mimir or Loki) in their respective feature/route-traffic-via-nginx branch
