### PR TITLE
fix: add `include /etc/nginx/mime.types` to nginx config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "2.0.17"
+version = "2.0.18"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/nginx.py
+++ b/src/coordinated_workers/nginx.py
@@ -232,7 +232,9 @@ class NginxLocationConfig:
     """Custom rewrite, used i.e. to drop the subpath from the proxied request if needed.
     Example: ['^/auth(/.*)$', '$1', 'break'] to drop `/auth` from the request.
     """
-    extra_directives: Dict[str, List[str]] = field(default_factory=lambda: cast(Dict[str, List[str]], {}))
+    extra_directives: Dict[str, List[str]] = field(
+        default_factory=lambda: cast(Dict[str, List[str]], {})
+    )
     """Dictionary of arbitrary location configuration keys and values.
     Example: {"proxy_ssl_verify": ["off"]}
     """
@@ -365,6 +367,11 @@ class NginxConfig:
                     {"directive": "fastcgi_temp_path", "args": ["/tmp/fastcgi_temp"]},
                     {"directive": "uwsgi_temp_path", "args": ["/tmp/uwsgi_temp"]},
                     {"directive": "scgi_temp_path", "args": ["/tmp/scgi_temp"]},
+                    # include mime types so nginx can map file extensions correctly.
+                    # Without this, files may fall back to "application/octet-stream",
+                    # and when Nginx serves static files, browsers may download them
+                    # instead of rendering (e.g., JS, CSS, SVG).
+                    {"directive": "include", "args": ["/etc/nginx/mime.types"]},
                     # logging
                     {"directive": "default_type", "args": ["application/octet-stream"]},
                     {

--- a/tests/unit/resources/sample_litmus_conf_with_rewrite.txt
+++ b/tests/unit/resources/sample_litmus_conf_with_rewrite.txt
@@ -19,6 +19,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_litmus_ssl_conf.txt
+++ b/tests/unit/resources/sample_litmus_ssl_conf.txt
@@ -19,6 +19,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_loki_nginx_conf.txt
+++ b/tests/unit/resources/sample_loki_nginx_conf.txt
@@ -31,6 +31,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_loki_nginx_conf_tls.txt
+++ b/tests/unit/resources/sample_loki_nginx_conf_tls.txt
@@ -31,6 +31,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_mimir_nginx_conf.txt
+++ b/tests/unit/resources/sample_mimir_nginx_conf.txt
@@ -39,6 +39,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_mimir_nginx_conf_tls.txt
+++ b/tests/unit/resources/sample_mimir_nginx_conf_tls.txt
@@ -39,6 +39,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_tempo_nginx_conf.txt
+++ b/tests/unit/resources/sample_tempo_nginx_conf.txt
@@ -39,6 +39,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_tempo_nginx_conf_root_path.txt
+++ b/tests/unit/resources/sample_tempo_nginx_conf_root_path.txt
@@ -39,6 +39,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/resources/sample_tempo_nginx_conf_tls.txt
+++ b/tests/unit/resources/sample_tempo_nginx_conf_tls.txt
@@ -39,6 +39,7 @@ http {
     fastcgi_temp_path /tmp/fastcgi_temp;
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
     map $status $loggable {

--- a/tests/unit/test_nginx.py
+++ b/tests/unit/test_nginx.py
@@ -280,9 +280,7 @@ def test_generate_nginx_config_with_extra_location_directives():
             enable_status_page=False,
         )
         generated_config = nginx.get_config(addrs_by_role, False, root_path="/dist")
-        sample_config_path = (
-                Path(__file__).parent / "resources" / "sample_litmus_ssl_conf.txt"
-        )
+        sample_config_path = Path(__file__).parent / "resources" / "sample_litmus_ssl_conf.txt"
         assert sample_config_path.read_text() == generated_config
 
 


### PR DESCRIPTION
Contributes to fixing https://github.com/canonical/litmus-operators/issues/46

TL;DR
Without this directive, nginx will fail to map file extensions correctly and as a result, browsers can't render content correctly thinking that they are binaries (octet-stream) not, for example, icons or stylesheets

## Solution
Add `include /etc/nginx/mime.types;`


## Tandem PRs
TODO
