### PR TITLE
enable CI runs against feature branches

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - track/**
+      - feat/**
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Issue
CI currently doesn't run when a PR against a `feat/*` branch is updated (for example, #74).  

## Solution
Trigger CI on pull request events for feature branches
