### PR TITLE
feat: add service-mesh support to Coordinator

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -53,11 +53,13 @@ check_libs_installed(
     "charms.observability_libs.v0.kubernetes_compute_resources_patch",
     "charms.tls_certificates_interface.v4.tls_certificates",
     "charms.catalogue_k8s.v1.catalogue",
+    "charms.istio_beacon_k8s.v0.service_mesh",
 )
 
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
+from charms.istio_beacon_k8s.v0.service_mesh import ServiceMeshConsumer
 from charms.loki_k8s.v1.loki_push_api import LogForwarder, LokiPushApiConsumer
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch,
@@ -181,6 +183,7 @@ _EndpointMapping = TypedDict(
         "send-datasource": Optional[str],
         "receive-datasource": Optional[str],
         "catalogue": Optional[str],
+        "service-mesh": Optional[str],
     },
     total=True,
 )
@@ -364,6 +367,10 @@ class Coordinator(ops.Object):
             )
             if self._resources_requests_getter
             else None
+        )
+
+        self._mesh = (
+            ServiceMeshConsumer(self._charm) if self._endpoints.get("service-mesh") else None
         )
 
         ## Observers

--- a/tests/integration/test_service_mesh.py
+++ b/tests/integration/test_service_mesh.py
@@ -1,0 +1,73 @@
+"""Test the coordinated-worker deploys correctly to a service mesh."""
+
+import lightkube
+import pytest
+from helpers import PackedCharm, deploy_coordinated_worker_solution
+from jubilant import Juju, all_active
+from lightkube.resources.core_v1 import Pod
+from pytest_jubilant.main import TempModelFactory
+
+COORDINATOR_NAME = "coordinator"
+WORKER_A_NAME = "worker-a"
+WORKER_B_NAME = "worker-b"
+ISTIO_K8S_NAME = "istio-k8s"
+ISTIO_BEACON_NAME = "istio-beacon-k8s"
+
+
+def test_deploy(juju: Juju, coordinator_charm: PackedCharm, worker_charm: PackedCharm):
+    deploy_coordinated_worker_solution(
+        juju,
+        coordinator_charm,
+        COORDINATOR_NAME,
+        worker_charm,
+        WORKER_A_NAME,
+        WORKER_B_NAME,
+    )
+
+
+@pytest.fixture(scope="module")
+def juju_istio_system(temp_model_factory: TempModelFactory):
+    """Return a Juju client configured for the istio-system model, automatically creating that model as needed.
+
+    The model will have the same name as the automatically generated test model, but with the suffix 'istio-system'.
+    """
+    yield temp_model_factory.get_juju(suffix="istio-system")
+
+
+def test_deploy_dependency_service_mesh(juju: Juju, juju_istio_system: Juju):
+    """Deploy the istio service mesh."""
+    juju_istio_system.deploy(
+        "istio-k8s",
+        app=ISTIO_K8S_NAME,
+        channel="2/edge",
+        trust=True,
+    )
+
+    juju.deploy(
+        "istio-beacon-k8s",
+        app=ISTIO_BEACON_NAME,
+        channel="2/edge",
+        trust=True,
+    )
+
+    juju_istio_system.wait(
+        lambda status: all_active(status, ISTIO_K8S_NAME),
+    )
+
+    juju.wait(
+        lambda status: all_active(status, ISTIO_BEACON_NAME),
+    )
+
+
+def test_configure_service_mesh(juju: Juju):
+    """Configure the coordinated-worker to use the service mesh."""
+    juju.integrate(COORDINATOR_NAME, ISTIO_BEACON_NAME)
+
+    juju.wait(
+        lambda status: all_active(status, COORDINATOR_NAME, ISTIO_BEACON_NAME),
+    )
+
+    # Assert that the Coordinator relation to service mesh worked correctly by checking for expected service mesh labels
+    lightkube_client = lightkube.Client()
+    coordinator_pod = lightkube_client.get(Pod, f"{COORDINATOR_NAME}-0", namespace=juju.model)
+    assert coordinator_pod.metadata.labels["istio.io/dataplane-mode"] == "ambient"

--- a/tests/integration/testers/coordinator/src/charm.py
+++ b/tests/integration/testers/coordinator/src/charm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
+"""Coordinator Charm."""
+
 import logging
 
 import ops
@@ -19,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class CoordinatorTester(CharmBase):
+    """A Juju Charmed Operator for testing the Coordinator."""
+
     def __init__(self, framework):
         super().__init__(framework)
 

--- a/tests/integration/testers/coordinator/src/coordinator_config.py
+++ b/tests/integration/testers/coordinator/src/coordinator_config.py
@@ -1,3 +1,5 @@
+"""Coordinator configuration."""
+
 from enum import StrEnum, unique
 
 from coordinated_workers.coordinator import ClusterRolesConfig
@@ -12,6 +14,7 @@ class Role(StrEnum):
 
     @staticmethod
     def all_nonmeta():
+        """Return all non-meta roles."""
         return {
             Role.a,
             Role.b,

--- a/tests/integration/testers/worker/src/charm.py
+++ b/tests/integration/testers/worker/src/charm.py
@@ -15,6 +15,8 @@ container_name = "echoserver"
 
 
 class WorkerCharm(CharmBase):
+    """A Juju Charmed Operator for testing the Worker."""
+
     def __init__(self, *args):
         super().__init__(*args)
         logging.error("WorkerCharm __init__")
@@ -31,6 +33,7 @@ class WorkerCharm(CharmBase):
         )
 
     def pebble_layer(self, worker: Worker) -> Layer:
+        """Pebble layer for the echo server."""
         layer = Layer(
             # Start a listener for each defined port
             {


### PR DESCRIPTION
## Issue
Closes #62

## Solution
Add mesh support using the service-mesh libraries

## Context
none

## Testing Instructions
Added integration test covers the change.  To manually test, run `test_service_mesh.py` then inspect the Coordinator pod for the istio labels

## Upgrade Notes
none