### PR TITLE
fix: use lightkube-extensions from the pypi instead of github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # charms.tls_certificates_interface.v4.tls_certificates
     "cryptography",
     "charmed-service-mesh-helpers>=0.2.0",
-    "lightkube-extensions@git+https://github.com/canonical/lightkube-extensions.git@0.1.0",
+    "lightkube-extensions",
     "cosl>=1.3.1",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ requires-dist = [
     { name = "crossplane" },
     { name = "cryptography" },
     { name = "lightkube", specifier = ">=0.15.4" },
-    { name = "lightkube-extensions", git = "https://github.com/canonical/lightkube-extensions.git?rev=0.1.0" },
+    { name = "lightkube-extensions" },
     { name = "ops", extras = ["tracing"] },
     { name = "pydantic" },
 ]
@@ -571,11 +571,11 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -636,11 +636,15 @@ wheels = [
 
 [[package]]
 name = "lightkube-extensions"
-version = "0.0.1"
-source = { git = "https://github.com/canonical/lightkube-extensions.git?rev=0.1.0#f82588c9f9b981fef931cc06441fd8df6e162fee" }
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "lightkube" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/e9/dd72ae3d124426d5b29c2e75f88131e11de8c59207697226eaf52bc72c61/lightkube_extensions-0.1.0.tar.gz", hash = "sha256:f112d077697ffb49ceb6ec48b2db33bb864e5660d744dbebf7f34d97cdf138cc", size = 17020, upload-time = "2025-10-20T16:37:22.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/b9/964fb1788b55018a0ed89735b7c0e3a4c02b63b3cbfabeb9144b48ebd76a/lightkube_extensions-0.1.0-py3-none-any.whl", hash = "sha256:556a9ccf2c551ff9654908ca7ed1077fc622d91fc1d2bd44b6719d7e708dc403", size = 17722, upload-time = "2025-10-20T16:37:21.564Z" },
 ]
 
 [[package]]
@@ -886,7 +890,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.2"
+version = "2.12.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -894,9 +898,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/35/d319ed522433215526689bad428a94058b6dd12190ce7ddd78618ac14b28/pydantic-2.12.2.tar.gz", hash = "sha256:7b8fa15b831a4bbde9d5b84028641ac3080a4ca2cbd4a621a661687e741624fd", size = 816358, upload-time = "2025-10-14T15:02:21.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/98/468cb649f208a6f1279448e6e5247b37ae79cf5e4041186f1e2ef3d16345/pydantic-2.12.2-py3-none-any.whl", hash = "sha256:25ff718ee909acd82f1ff9b1a4acfd781bb23ab3739adaa7144f19a6a4e231ae", size = 460628, upload-time = "2025-10-14T15:02:19.623Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
Currently releasing to pypi fails because the dependency list includes a dependency [`lightkube-extensions`](https://github.com/canonical/cos-coordinated-workers/blob/d8d9b3e609bbb14810195b339207fbc0b6e9128a/pyproject.toml#L25) directly from its [github repo](https://github.com/canonical/lightkube-extensions).

## Solution
`lightkube-extensions` is now [released](https://pypi.org/project/lightkube-extensions/) to `pypi`. So, the github url in the `pyproject.toml` is now replaced with the package name of `lightkube-extensions` in `pypi`. 



