### PR TITLE
fix: adds logging for service mesh operations

### DIFF
--- a/src/coordinated_workers/service_mesh.py
+++ b/src/coordinated_workers/service_mesh.py
@@ -188,7 +188,10 @@ def reconcile_cluster_internal_mesh_policies(
     mesh_type = mesh.mesh_type()
     prm = _get_policy_resource_manager(charm, logger)
     if mesh_type:
-        # if mesh_type exists, the charm is connected to a service mesh charm. reconcile the cluster internal policies.
+        logger.info(
+            "Service mesh relation active (mesh_type=%s). Reconciling coordinator-worker mesh policies.",
+            mesh_type,
+        )
         policies = _get_cluster_internal_mesh_policies(
             charm,
             cluster,
@@ -196,5 +199,7 @@ def reconcile_cluster_internal_mesh_policies(
         )
         prm.reconcile(policies, mesh_type)  # type: ignore[reportUnknownMemberType]
     else:
-        # if mesh_type is None, there is no active service-mesh relation. silently purge all policies, if any.
+        logger.info(
+            "No active service-mesh relation found. Cleaning up coordinator-worker mesh policies, if any."
+        )
         prm.delete()

--- a/tests/integration/test_service_mesh.py
+++ b/tests/integration/test_service_mesh.py
@@ -69,7 +69,7 @@ def test_deploy_dependency_service_mesh(juju: Juju, juju_istio_system: Juju):
 
 def test_configure_service_mesh(juju: Juju):
     """Configure the coordinated-worker to use the service mesh."""
-    juju.integrate(COORDINATOR_NAME, ISTIO_BEACON_NAME)
+    juju.integrate(f"{COORDINATOR_NAME}:service-mesh", ISTIO_BEACON_NAME)
 
     juju.wait(
         lambda status: all_active(status, COORDINATOR_NAME, ISTIO_BEACON_NAME),


### PR DESCRIPTION
## Issue
Fixes #135 


## Solution
Adds logging for mesh operations carried out by the coordinator

## Tandem
In tandem to this, the lightkube-extensions package itself now wraps the transient transport error in a custom cleaner error class - https://github.com/canonical/lightkube-extensions/pull/12