### PR TITLE
test: use pytest-jubilant 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "ruff",
     # INTEGRATION TESTS
     "jubilant",
-    "pytest-jubilant>=1.2.0",
+    "pytest-jubilant>=2,<3",
     "sh",
     "tenacity",
     "juju-doctor"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,8 +11,7 @@ from pathlib import Path
 from typing import Union
 
 import pytest
-from helpers import PackedCharm
-from pytest_jubilant import get_resources, pack
+from helpers import PackedCharm, get_resources, pack
 
 logger = logging.getLogger(__name__)
 store = defaultdict(str)
@@ -85,7 +84,7 @@ def _tester_charm_builder(tester_path: Path) -> PackedCharm:
         logger.info(f"Packing tester charm {tester_charm_name} from {tester_path}")
         charm = pack(tester_path)
 
-    resources = get_resources(tester_path)
+    resources = get_resources(tester_path / "charmcraft.yaml")
 
     return PackedCharm(
         charm=str(charm),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,10 +1,13 @@
 """Helper functions for integration tests."""
 
 import logging
+import subprocess
 from dataclasses import asdict, dataclass
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import sh
+import yaml
 from jubilant import Juju, all_active, all_blocked
 from tenacity import (
     retry,
@@ -121,3 +124,39 @@ def assert_request_returns_http_code(
     assert returned_code == code, (
         f"Expected {code} but got {returned_code} for {source_unit} -> {target_url} on {method}"
     )
+
+
+def pack(root: Union[Path, str] = "./", platform: str | None = None) -> Path:
+    """Pack a local charm and return it."""
+    cmd = ["charmcraft", "pack", "--project-dir", root]
+    if platform:
+        cmd.extend(["--platform", platform])
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    # stderr looks like:
+    # > charmcraft pack
+    # Packed tempo-coordinator-k8s_ubuntu@24.04-amd64.charm
+    # Packed tempo-coordinator-k8s_ubuntu@22.04-amd64.charm
+    packed_charms = [
+        line.split()[1]
+        for line in proc.stderr.strip().splitlines()
+        if line.startswith("Packed")
+    ]
+    if not packed_charms:
+        raise ValueError(
+            "Unable to get packed charm(s)!"
+            f" ({cmd!r} completed with {proc.returncode=}, {proc.stdout=}, {proc.stderr=})"
+        )
+    if len(packed_charms) > 1:
+        raise ValueError(
+            "This charm supports multiple platforms. "
+            "Pass a `platform` argument to control which charm you're getting instead."
+        )
+    return Path(packed_charms[0]).resolve()
+
+
+def get_resources(path: Union[Path, str] = Path("charmcraft.yaml")) -> dict[str, str]:
+    meta = yaml.safe_load(Path(path).read_text())
+    return {
+        resource: data["upstream-source"]
+        for resource, data in meta["resources"].items()
+    }

--- a/tests/integration/test_service_mesh.py
+++ b/tests/integration/test_service_mesh.py
@@ -13,7 +13,7 @@ from helpers import (
 )
 from jubilant import Juju, all_active, all_blocked
 from lightkube.resources.core_v1 import Pod
-from pytest_jubilant import TempModelFactory
+from pytest_jubilant import JujuFactory
 
 COORDINATOR_NAME = "coordinator"
 WORKER_A_NAME = "worker-a"
@@ -34,12 +34,12 @@ def test_deploy(juju: Juju, coordinator_charm: PackedCharm, worker_charm: Packed
 
 
 @pytest.fixture(scope="module")
-def juju_istio_system(temp_model_factory: TempModelFactory):
+def juju_istio_system(juju_factory: JujuFactory):
     """Return a Juju client configured for the istio-system model, automatically creating that model as needed.
 
     The model will have the same name as the automatically generated test model, but with the suffix 'istio-system'.
     """
-    yield temp_model_factory.get_juju(suffix="istio-system")
+    yield juju_factory.get_juju(suffix="istio-system")
 
 
 def test_deploy_dependency_service_mesh(juju: Juju, juju_istio_system: Juju):

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-jubilant", specifier = ">=1.2.0" },
+    { name = "pytest-jubilant", specifier = ">=2,<3" },
     { name = "ruff" },
     { name = "sh" },
     { name = "tenacity" },
@@ -1113,15 +1113,15 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "1.2.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/36767aac16f831fd4a415903b9b00832f68b372b1eb00a008d0754e8cd7e/pytest_jubilant-1.2.0.tar.gz", hash = "sha256:5f7dcbe2c73a3add79042897f48dcf025d52b6724dd3b7530e2366f3bc1ad3a4", size = 12204, upload-time = "2026-03-11T02:02:29.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/b6/d98999f1d0a0c9313154fe7bf8f4e3639729b7052c736f2f12cd7025201c/pytest_jubilant-2.0.0.tar.gz", hash = "sha256:c5f8382ac0b43bca8ef87e309f587e2fc1751ff7b2677dd28a66989b6605e063", size = 16250, upload-time = "2026-03-29T23:39:57.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/30/327b1996df3e652a99badb593ae18ebb1a0bba511ef900f4f4a35d96307c/pytest_jubilant-1.2.0-py3-none-any.whl", hash = "sha256:5809b5c2498b67fede742827d0df2fe71ee447a9894e2ce9ed60af9f201d738b", size = 11893, upload-time = "2026-03-11T02:02:28.141Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c3/234c3ec22b230e7e33732f91d19d72ad84101a97353b03be3450e4188c5c/pytest_jubilant-2.0.0-py3-none-any.whl", hash = "sha256:28fcf3750100eda16658c2967af099a39199af9fd102ab3b5ba230a028efec3e", size = 13354, upload-time = "2026-03-29T23:39:56.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The `pytest-jubilant` [2.0 release](https://github.com/canonical/pytest-jubilant/releases/tag/v2.0.0) breaks this repo's tests.

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR migrates the tests to use the 2.0 API. This includes defining copies of the `pack` and `get_resources` helpers dropped from `pytest-jubilant`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Charm Tech will maintain the `pytest-jubilant` 2.0 API going forward. We dropped `pack` and `get_resources` to scope the library more tightly to `pytest` + `jubilant`. In general, we think it's cleaner to avoid calling `charmcraft pack` inside your Python integration test suite.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Integration tests should pass.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A.