### PR TITLE
feat: improve ClusterRoleConfig post_init error messages

### DIFF
--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -149,7 +149,7 @@ class ClusterRolesConfig:
         roles_set = set(self.roles)
         meta_keys = set(self.meta_roles.keys())
 
-        error_messages = []
+        error_messages: list[str] = []
 
         if not meta_keys.issubset(roles_set):
             error_messages.append(

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -146,21 +146,31 @@ class ClusterRolesConfig:
 
     def __post_init__(self):
         """Ensure the various role specifications are consistent with one another."""
-        are_meta_keys_valid = set(self.meta_roles.keys()).issubset(self.roles)
-        are_meta_values_valid = all(
-            set(meta_value).issubset(self.roles) for meta_value in self.meta_roles.values()
+        are_meta_keys_valid = (
+            set(self.meta_roles.keys()).issubset(self.roles)
+            or f"The meta keys {set(self.meta_roles.keys())} are not a subset of {self.roles}."
         )
-        is_minimal_valid = set(self.minimal_deployment).issubset(self.roles)
-        if not all(
-            [
+        are_meta_values_valid = (
+            all(set(meta_value).issubset(self.roles) for meta_value in self.meta_roles.values())
+            or f"The meta values are not a subset of {self.roles}."
+        )
+        is_minimal_valid = (
+            set(self.minimal_deployment).issubset(self.roles)
+            or f"The minimal deployment {self.minimal_deployment} is not a subset of {self.roles}."
+        )
+
+        error_messages = [
+            m
+            for m in (
                 are_meta_keys_valid,
                 are_meta_values_valid,
                 is_minimal_valid,
-            ]
-        ):
-            raise ClusterRolesConfigError(
-                "Invalid ClusterRolesConfig: The configuration is not coherent."
             )
+            if isinstance(m, str)
+        ]
+        if error_messages:
+            error_messages_text = ",\n".join(error_messages)
+            raise ClusterRolesConfigError(f"Invalid ClusterRolesConfig: {error_messages_text}")
 
     def is_coherent_with(self, cluster_roles: Iterable[str]) -> bool:
         """Returns True if the provided roles satisfy the minimal deployment spec; False otherwise."""

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -146,28 +146,22 @@ class ClusterRolesConfig:
 
     def __post_init__(self):
         """Ensure the various role specifications are consistent with one another."""
-        are_meta_keys_valid = (
-            set(self.meta_roles.keys()).issubset(self.roles)
-            or f"The meta keys {set(self.meta_roles.keys())} are not a subset of {self.roles}."
-        )
-        are_meta_values_valid = (
-            all(set(meta_value).issubset(self.roles) for meta_value in self.meta_roles.values())
-            or f"The meta values are not a subset of {self.roles}."
-        )
-        is_minimal_valid = (
-            set(self.minimal_deployment).issubset(self.roles)
-            or f"The minimal deployment {self.minimal_deployment} is not a subset of {self.roles}."
-        )
+        roles_set = set(self.roles)
+        meta_keys = set(self.meta_roles.keys())
 
-        error_messages = [
-            m
-            for m in (
-                are_meta_keys_valid,
-                are_meta_values_valid,
-                is_minimal_valid,
+        error_messages = []
+
+        if not meta_keys.issubset(roles_set):
+            error_messages.append(
+                f"The meta keys {sorted(meta_keys)} are not a subset of {sorted(roles_set)}."
             )
-            if isinstance(m, str)
-        ]
+        if not all(set(meta_value).issubset(roles_set) for meta_value in self.meta_roles.values()):
+            error_messages.append(f"The meta values are not a subset of {sorted(roles_set)}.")
+        if not set(self.minimal_deployment).issubset(roles_set):
+            error_messages.append(
+                f"The minimal deployment {sorted(self.minimal_deployment)} is not a subset of {sorted(roles_set)}."
+            )
+
         if error_messages:
             error_messages_text = ",\n".join(error_messages)
             raise ClusterRolesConfigError(f"Invalid ClusterRolesConfig: {error_messages_text}")

--- a/tests/unit/test_roles_config.py
+++ b/tests/unit/test_roles_config.py
@@ -7,33 +7,39 @@ def test_meta_role_keys_not_in_roles():
     """Meta roles keys must be a subset of roles."""
     # WHEN `meta_roles` has a key that is not specified in `roles`
     # THEN instantiation raises a ClusterRolesConfigError
-    with pytest.raises(ClusterRolesConfigError):
+    with pytest.raises(ClusterRolesConfigError, match="meta keys") as exc_info:
         ClusterRolesConfig(
             roles={"read"},
             meta_roles={"I AM NOT A SUBSET OF ROLES": {"read"}},
             minimal_deployment={"read"},
         )
+    assert "meta keys" in str(exc_info.value)
+    assert "not a subset of" in str(exc_info.value)
 
 
 def test_meta_role_values_not_in_roles():
     """Meta roles values must be a subset of roles."""
     # WHEN `meta_roles` has a value that is not specified in `roles`
     # THEN instantiation raises a ClusterRolesConfigError
-    with pytest.raises(ClusterRolesConfigError):
+    with pytest.raises(ClusterRolesConfigError, match="meta values") as exc_info:
         ClusterRolesConfig(
             roles={"read"},
             meta_roles={"read": {"I AM NOT A SUBSET OF ROLES"}},
             minimal_deployment={"read"},
         )
+    assert "meta values" in str(exc_info.value)
+    assert "not a subset of" in str(exc_info.value)
 
 
 def test_minimal_deployment_roles_not_in_roles():
     """Minimal deployment roles must be a subset of roles."""
     # WHEN `minimal_deployment` has a value that is not specified in `roles`
     # THEN instantiation raises a ClusterRolesConfigError
-    with pytest.raises(ClusterRolesConfigError):
+    with pytest.raises(ClusterRolesConfigError, match="minimal deployment") as exc_info:
         ClusterRolesConfig(
             roles={"read"},
             meta_roles={"read": {"read"}},
             minimal_deployment={"I AM NOT A SUBSET OF ROLES"},
         )
+    assert "minimal deployment" in str(exc_info.value)
+    assert "not a subset of" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Supersedes #79 by rebasing onto main and fixing issues found in review.

- **Conflict resolution**: Rebased onto main which removed `recommended_deployment`; kept main's 3-check structure with PR #79's improved error message pattern
- **Syntax fix**: Removed stray `)` in the `error_messages` list comprehension that caused a `SyntaxError`
- **Copy-paste fix**: `are_meta_keys_valid` now reports "meta keys" instead of duplicating the "meta values" message from `are_meta_values_valid`

Each validation check uses the `(condition or "error string")` pattern so that on failure, the specific error message is collected and reported, replacing the generic "The configuration is not coherent" message.