### PR TITLE
fix: pass platform to `pack` command

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Union
 
 import pytest
-from helpers import PackedCharm, get_resources, pack
+from helpers import PackedCharm, get_platforms, get_resources, pack
 
 logger = logging.getLogger(__name__)
 store = defaultdict(str)
@@ -82,7 +82,8 @@ def _tester_charm_builder(tester_path: Path) -> PackedCharm:
         _copy_coordinated_worker_source(destination=tester_coordinated_worker_source)
         _copy_coordinated_worker_project_files(destination=tester_path)
         logger.info(f"Packing tester charm {tester_charm_name} from {tester_path}")
-        charm = pack(tester_path)
+        platforms = get_platforms(tester_path / "charmcraft.yaml")
+        charm = pack(tester_path, platform=platforms) if platforms else pack(tester_path)
 
     resources = get_resources(tester_path / "charmcraft.yaml")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Union
 
 import pytest
-from helpers import PackedCharm, get_platforms, get_resources, pack
+from helpers import PackedCharm, get_most_recent_platform, get_resources, pack
 
 logger = logging.getLogger(__name__)
 store = defaultdict(str)
@@ -82,7 +82,7 @@ def _tester_charm_builder(tester_path: Path) -> PackedCharm:
         _copy_coordinated_worker_source(destination=tester_coordinated_worker_source)
         _copy_coordinated_worker_project_files(destination=tester_path)
         logger.info(f"Packing tester charm {tester_charm_name} from {tester_path}")
-        platforms = get_platforms(tester_path / "charmcraft.yaml")
+        platforms = get_most_recent_platform(tester_path / "charmcraft.yaml")
         charm = pack(tester_path, platform=platforms) if platforms else pack(tester_path)
 
     resources = get_resources(tester_path / "charmcraft.yaml")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for integration tests."""
 
 import logging
+import re
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -155,3 +156,18 @@ def pack(root: Union[Path, str] = "./", platform: str | None = None) -> Path:
 def get_resources(path: Union[Path, str] = Path("charmcraft.yaml")) -> dict[str, str]:
     meta = yaml.safe_load(Path(path).read_text())
     return {resource: data["upstream-source"] for resource, data in meta["resources"].items()}
+
+def get_platforms(path: Union[Path, str] = Path("charmcraft.yaml")) -> list[str]:
+    try:
+        meta = yaml.safe_load(Path(path).read_text())
+    except FileNotFoundError:
+        return []
+
+    platforms_dict = meta.get("platforms")
+    if not platforms_dict:
+        return []
+    # Since `platforms` is a dict of platform name to build instructions, we just want the platform names
+    # So we need a list of the keys
+    platform_names = list(platforms_dict.keys())
+    # Return the last platform in the list, which should be the most recent version.
+    return platform_names[-1]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for integration tests."""
 
 import logging
+import platform
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -157,17 +158,30 @@ def get_resources(path: Union[Path, str] = Path("charmcraft.yaml")) -> dict[str,
     return {resource: data["upstream-source"] for resource, data in meta["resources"].items()}
 
 
-def get_platforms(path: Union[Path, str] = Path("charmcraft.yaml")) -> list[str]:
+def get_most_recent_platform(path: Union[Path, str] = Path("charmcraft.yaml")) -> str | None:
     try:
         meta = yaml.safe_load(Path(path).read_text())
-    except FileNotFoundError:
-        return []
+    except (FileNotFoundError, yaml.YAMLError):
+        return None
 
     platforms_dict = meta.get("platforms")
-    if not platforms_dict:
-        return []
-    # Since `platforms` is a dict of platform name to build instructions, we just want the platform names
-    # So we need a list of the keys
-    platform_names = list(platforms_dict.keys())
-    # Return the last platform in the list, which should be the most recent version.
-    return platform_names[-1]
+    if not platforms_dict or not isinstance(platforms_dict, dict):
+        return None
+
+    # It's unlikely that we'll have a tester charm that supports the ARM architecture,
+    # but if we do,
+    # we want to make sure we get the right one for the machine we're running on.
+    # This would be useful for local testing on ARM machines, for example.
+    # Note we only check for ARM vs AMD, since those are the only two archs that
+    # tend to be used locally or on CI.
+    machine_arch = platform.machine().lower()
+
+    if "arm" in machine_arch or "aarch" in machine_arch:
+        target = "arm"
+    else:
+        target = "amd"
+
+    filtered_platforms = [name for name in platforms_dict.keys() if target in name.lower()]
+
+    # We return the last platform in the list, with the assumption that it must be the most recent.
+    return filtered_platforms[-1] if filtered_platforms else None

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,7 +1,6 @@
 """Helper functions for integration tests."""
 
 import logging
-import re
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -156,6 +155,7 @@ def pack(root: Union[Path, str] = "./", platform: str | None = None) -> Path:
 def get_resources(path: Union[Path, str] = Path("charmcraft.yaml")) -> dict[str, str]:
     meta = yaml.safe_load(Path(path).read_text())
     return {resource: data["upstream-source"] for resource, data in meta["resources"].items()}
+
 
 def get_platforms(path: Union[Path, str] = Path("charmcraft.yaml")) -> list[str]:
     try:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Unblocks CI in #163.

Ever since central CI bumped to Charmcraft 4, our integration test setup in this repo has been unsuccessful.
The initial packing failure occurs because charmcraft pack --project-dir inaccurately falls back to an Ubuntu 22.04 environment check, which conflicts with our tester charm’s strict configuration for Ubuntu 24.04. Consequently, if we change directories into the folder and pack it works, but if we specify a --project-dir from outside, the build mismatches and fails. It's a result of bumping to Charmcraft 4.

## Solution
<!-- A summary of the solution addressing the above issue -->
Fixed this behaviour by explicitly passing the --platform ubuntu@24.04:amd64 flag, and corrected the helper and confest codes to properly parse and sort the platforms data as a dictionary instead of a list.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
