### PR TITLE
fix: conditionally attempt to grant private key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coordinated-workers"
-version = "4.1.0"
+version = "4.1.1"
 authors = [
     { name = "michaeldmitry", email = "33381599+michaeldmitry@users.noreply.github.com" },
 ]

--- a/src/coordinated_workers/coordinator.py
+++ b/src/coordinated_workers/coordinator.py
@@ -1001,7 +1001,7 @@ class Coordinator(ops.Object):
             # https://github.com/canonical/cos-coordinated-workers/issues/16
             privkey_secret_id=self.cluster.grant_privkey(
                 self._certificates._get_private_key_secret_label(mode=Mode.UNIT)  # type: ignore
-            ),
+            ) if tls_config else None,
             charm_tracing_receivers=self._charm_tracing_receivers_urls,
             workload_tracing_receivers=self._workload_tracing_receivers_urls,
             remote_write_endpoints=self.remote_write_endpoints,


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #169.

The issue stems from the recent migration from the Charmhub-hosted tls_certificates lib to the PyPI package in https://github.com/canonical/cos-coordinated-workers/commit/2ef769a8c4e56c304085272814d3c97541156557.

The PyPI based `TLSCertificatesRequiresV4` deletes the private key secret on `relation_broken`, as you can see [here](https://github.com/canonical/charmlibs/blob/a1426c43537decaf33998f4f04ded84636807b55/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_tls_certificates.py#L2104).

Hence, by the time the Coordinator tries to grant that secret, the secret is already gone, resulting in an uncaught SecretNotFoundError:

https://github.com/canonical/cos-coordinated-workers/blob/b9fb9f56ad7ef58b63ace0e789f915e9585a3483/src/coordinated_workers/coordinator.py#L1002-L1004

We should guard the granting of the private key and do it IFF we have TLS configured.
## Solution
<!-- A summary of the solution addressing the above issue -->
Guard the granting of the private key so that we grant attempt to retrieve and grant the private key IFF if TLS is available.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### The "before" bevaviour"
Deploy the following bundle.
```yaml
bundle: kubernetes

applications:
  ssc:
    charm: self-signed-certificates
    channel: 1/stable
    revision: 588
    base: ubuntu@22.04/stable
    scale: 1
    constraints: arch=amd64

  swfs-t:
    charm: seaweedfs-k8s
    channel: latest/edge
    revision: 9
    resources:
      seaweedfs-image: 2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true

  tempo:
    charm: tempo-coordinator-k8s
    channel: dev/edge
    revision: 156
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 9
      nginx-prometheus-exporter-image: 5
    scale: 1
    constraints: arch=amd64
    trust: true

  tempo-worker:
    charm: tempo-worker-k8s
    channel: dev/edge
    revision: 110
    base: ubuntu@26.04/stable
    resources:
      tempo-image: 14
    scale: 1
    options:
      role-all: true
    constraints: arch=amd64
    storage:
      wal: kubernetes,1,1024M
    trust: true

relations:
  - - tempo:tempo-cluster
    - tempo-worker:tempo-cluster

  - - tempo:s3
    - swfs-t:s3-credentials

  - - tempo:certificates
    - ssc:certificates
```

When you remove the SSC-Tempo relation (`jrmrel tempo ssc`), Tempo goes into error state.

### The "after" behaviour
Change the CW dependency in Tempo coordinator so it sources CW from this branch. Pack and refresh Tempo.

Now, removing and readding the relation should not cause Tempo go into error state.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
Since this issue applies to the Mimir, Tempo, and Loki coordinators, we should release this change to PyPI and then bump the dep in those charms.